### PR TITLE
Add GitHub authentication startup script for worker agents

### DIFF
--- a/start-up.sh
+++ b/start-up.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+echo "🔧 Configuring GitHub authentication for worker agent..."
+
+# Check for GITHUB_TOKEN env var
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "⚠️  Warning: GITHUB_TOKEN environment variable is not set"
+    echo "   GitHub authentication will not be configured"
+    exit 0
+fi
+
+# Authenticate with gh using the token
+echo "🔐 Authenticating with GitHub CLI..."
+echo "$GITHUB_TOKEN" | gh auth login --with-token
+
+# Configure git to use gh as credential helper
+echo "🔗 Configuring git credential helper..."
+git config --global credential.helper '!gh auth git-credential'
+
+# Set git user configuration
+echo "👤 Setting git user configuration..."
+git config --global user.email "worker-agent@desplega.ai"
+git config --global user.name "Worker Agent"
+
+echo "✅ GitHub authentication configured successfully!"
+
+# Verify configuration
+echo "📋 Verifying authentication..."
+gh auth status


### PR DESCRIPTION
## Summary
This PR adds a startup script (`start-up.sh`) that configures GitHub authentication for worker agents.

## Changes
- Created `/start-up.sh` script that:
  - Checks for `GITHUB_TOKEN` environment variable
  - Authenticates with GitHub CLI using `gh auth login --with-token`
  - Configures git credential helper to use gh: `git config --global credential.helper '!gh auth git-credential'`
  - Sets git user configuration (email: `worker-agent@desplega.ai`, name: `Worker Agent`)
  - Gracefully handles missing `GITHUB_TOKEN` with a warning message

## Test Plan
- [x] Script syntax validated with `bash -n`
- [x] Tested script execution without `GITHUB_TOKEN` - correctly displays warning and exits gracefully
- [x] Script is executable (`chmod +x`)

## Why This Matters
This solves the issue where worker agents couldn't push branches or create PRs because they lacked proper GitHub authentication. With this script, workers can be configured at startup to have full GitHub access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)