### PR TITLE
Add plan checkbox hooks for implementing skill

### DIFF
--- a/cc-plugin/base/.claude-plugin/plugin.json
+++ b/cc-plugin/base/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "desplega",
     "description": "Plugin for effective agentic development",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "author": {
         "name": "desplega.ai",
         "email": "contact@desplega.ai"

--- a/cc-plugin/base/hooks/plan_checkbox_reminder.py
+++ b/cc-plugin/base/hooks/plan_checkbox_reminder.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""PostToolUse hook that reminds Claude to update plan checkboxes."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from plan_utils import count_unchecked_items, find_active_plan, is_plan_file, should_throttle
+
+
+def _build_reminder(plan_path: str, unchecked_count: int, unchecked_lines: list[str]) -> str:
+    preview = unchecked_lines[:5]
+    details = "\n".join(preview)
+    if unchecked_count > len(preview):
+        details = f"{details}\n... ({unchecked_count - len(preview)} more)"
+
+    return (
+        "Plan checkbox reminder:\n"
+        f"Active plan: {plan_path}\n"
+        f"Unchecked checklist items remaining: {unchecked_count}\n"
+        "If you completed work, update the plan checkboxes.\n"
+        f"{details}"
+    ).strip()
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    session_id = data.get("session_id")
+    cwd = data.get("cwd")
+    tool_input = data.get("tool_input") or {}
+    file_path = tool_input.get("file_path", "")
+
+    if not session_id or not cwd:
+        sys.exit(0)
+
+    if is_plan_file(file_path):
+        sys.exit(0)
+
+    if should_throttle(session_id):
+        sys.exit(0)
+
+    plan_path = find_active_plan(session_id, cwd)
+    if not plan_path:
+        sys.exit(0)
+
+    unchecked_count, unchecked_lines = count_unchecked_items(plan_path, automated_only=False)
+    if unchecked_count <= 0:
+        sys.exit(0)
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "additionalContext": _build_reminder(
+                        plan_path, unchecked_count, unchecked_lines
+                    )
+                }
+            }
+        )
+    )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/cc-plugin/base/hooks/plan_checkbox_stop.py
+++ b/cc-plugin/base/hooks/plan_checkbox_stop.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Stop hook that enforces automated verification checkbox updates."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+from plan_utils import (
+    count_unchecked_by_phase,
+    find_active_plan,
+    marker_exists,
+    unchecked_items_by_phase,
+)
+
+PHASE_NUMBER_RE = re.compile(r"^Phase\s+(\d+)\b")
+
+
+def _is_started_phase(
+    phase_name: str, has_any_checked: bool, has_marker: bool, has_active_plan: bool
+) -> bool:
+    if has_any_checked:
+        return True
+
+    match = PHASE_NUMBER_RE.match(phase_name)
+    if not match:
+        return False
+
+    # Marker files are best-effort (sandboxed runs may not allow ~/.claude writes),
+    # so keep the Phase 1 cold-start behavior even when marker persistence fails.
+    return int(match.group(1)) == 1 and (has_marker or has_active_plan)
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    if data.get("stop_hook_active"):
+        sys.exit(0)
+
+    session_id = data.get("session_id")
+    cwd = data.get("cwd")
+    if not session_id or not cwd:
+        sys.exit(0)
+
+    plan_path = find_active_plan(session_id, cwd)
+    if not plan_path:
+        sys.exit(0)
+
+    phase_counts = count_unchecked_by_phase(plan_path, automated_only=True)
+    if not phase_counts:
+        sys.exit(0)
+
+    phase_items = unchecked_items_by_phase(plan_path, automated_only=True)
+    has_marker = marker_exists(session_id)
+
+    blocking_lines: list[str] = []
+    for phase_name, (unchecked_count, has_any_checked) in phase_counts.items():
+        if unchecked_count <= 0:
+            continue
+        if not _is_started_phase(
+            phase_name, has_any_checked, has_marker, has_active_plan=bool(plan_path)
+        ):
+            continue
+
+        unchecked_for_phase = phase_items.get(phase_name, [])
+        if not unchecked_for_phase:
+            blocking_lines.append(
+                f"{phase_name}: {unchecked_count} unchecked automated verification item(s)"
+            )
+            continue
+
+        for item in unchecked_for_phase:
+            blocking_lines.append(f"{phase_name}: {item}")
+
+    if not blocking_lines:
+        sys.exit(0)
+
+    reason = (
+        "Cannot stop yet. The active plan has unchecked automated verification items in started phases.\n"
+        f"Plan: {plan_path}\n"
+        "Unchecked items:\n"
+        + "\n".join(f"- {line}" for line in blocking_lines)
+        + "\nUpdate automated verification checkboxes before stopping."
+    )
+
+    print(json.dumps({"decision": "block", "reason": reason}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/cc-plugin/base/hooks/plan_utils.py
+++ b/cc-plugin/base/hooks/plan_utils.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Shared utilities for plan checkbox hooks."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+MARKER_DIR = Path.home() / ".claude" / "active-plans"
+UNCHECKED_RE = re.compile(r"^\s*-\s\[\s\]\s*(.*)$")
+CHECKED_RE = re.compile(r"^\s*-\s\[[xX]\]\s*(.*)$")
+PHASE_RE = re.compile(r"^##\s+Phase\s+(\d+)\s*:\s*(.+)$")
+STATUS_RE = re.compile(r"^\s*status\s*:\s*['\"]?([^'\"]+)['\"]?\s*$")
+
+
+def _safe_session_id(session_id: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", session_id or "unknown")
+    return safe or "unknown"
+
+
+def marker_path(session_id: str) -> Path:
+    return MARKER_DIR / f"{_safe_session_id(session_id)}.json"
+
+
+def marker_exists(session_id: str) -> bool:
+    return marker_path(session_id).exists()
+
+
+def _read_marker_plan_path(session_id: str) -> str | None:
+    marker = marker_path(session_id)
+    if not marker.exists():
+        return None
+
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    plan_path = data.get("plan_path")
+    if not plan_path:
+        return None
+
+    candidate = Path(plan_path).expanduser()
+    try:
+        resolved = candidate.resolve()
+    except OSError:
+        return None
+
+    if not resolved.is_file():
+        return None
+    return str(resolved)
+
+
+def _has_in_progress_status(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+    if not text.startswith("---"):
+        return False
+
+    lines = text.splitlines()
+    closing_index = None
+    for idx, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            closing_index = idx
+            break
+
+    if closing_index is None:
+        return False
+
+    for line in lines[1:closing_index]:
+        match = STATUS_RE.match(line)
+        if not match:
+            continue
+        status = match.group(1).strip().strip('"').strip("'")
+        return status == "in-progress"
+
+    return False
+
+
+def _scan_for_in_progress_plan(cwd: str) -> str | None:
+    thoughts_root = Path(cwd).resolve() / "thoughts"
+    if not thoughts_root.is_dir():
+        return None
+
+    candidates: list[Path] = []
+    for path in thoughts_root.rglob("*.md"):
+        if _has_in_progress_status(path):
+            candidates.append(path.resolve())
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda p: ("/plans/" not in p.as_posix(), str(p)))
+    return str(candidates[0])
+
+
+def find_active_plan(session_id: str, cwd: str) -> str | None:
+    marker_plan_path = _read_marker_plan_path(session_id)
+    if marker_plan_path:
+        return marker_plan_path
+
+    scanned_plan_path = _scan_for_in_progress_plan(cwd)
+    if not scanned_plan_path:
+        return None
+
+    create_marker(session_id, scanned_plan_path)
+    return scanned_plan_path
+
+
+def _read_plan_lines(plan_path: str) -> list[str]:
+    try:
+        return Path(plan_path).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+
+def count_unchecked_items(plan_path: str, automated_only: bool = False) -> tuple[int, list[str]]:
+    unchecked_lines: list[str] = []
+    in_automated_section = False
+
+    for raw_line in _read_plan_lines(plan_path):
+        stripped = raw_line.strip()
+
+        if automated_only:
+            if stripped.startswith("#### Automated Verification:"):
+                in_automated_section = True
+                continue
+            if in_automated_section and (
+                stripped.startswith("#### ")
+                or stripped.startswith("### ")
+                or stripped.startswith("## ")
+                or stripped == "---"
+            ):
+                in_automated_section = False
+
+        if not UNCHECKED_RE.match(raw_line):
+            continue
+        if automated_only and not in_automated_section:
+            continue
+
+        unchecked_lines.append(stripped)
+
+    return len(unchecked_lines), unchecked_lines
+
+
+def _collect_phase_data(
+    plan_path: str, automated_only: bool = False
+) -> dict[str, tuple[list[str], bool]]:
+    phase_order: list[str] = []
+    unchecked_by_phase: dict[str, list[str]] = {}
+    has_checked_by_phase: dict[str, bool] = {}
+
+    current_phase: str | None = None
+    in_automated_section = False
+
+    for raw_line in _read_plan_lines(plan_path):
+        stripped = raw_line.strip()
+        phase_match = PHASE_RE.match(stripped)
+
+        if phase_match:
+            current_phase = f"Phase {phase_match.group(1)}: {phase_match.group(2).strip()}"
+            if current_phase not in unchecked_by_phase:
+                phase_order.append(current_phase)
+                unchecked_by_phase[current_phase] = []
+                has_checked_by_phase[current_phase] = False
+            in_automated_section = False
+            continue
+
+        if current_phase is None:
+            continue
+
+        if stripped.startswith("#### Automated Verification:"):
+            in_automated_section = True
+            continue
+        if in_automated_section and (
+            stripped.startswith("#### ")
+            or stripped.startswith("### ")
+            or stripped.startswith("## ")
+            or stripped == "---"
+        ):
+            in_automated_section = False
+
+        if CHECKED_RE.match(raw_line):
+            has_checked_by_phase[current_phase] = True
+
+        if not UNCHECKED_RE.match(raw_line):
+            continue
+        if automated_only and not in_automated_section:
+            continue
+
+        unchecked_by_phase[current_phase].append(stripped)
+
+    return {
+        phase_name: (unchecked_by_phase[phase_name], has_checked_by_phase[phase_name])
+        for phase_name in phase_order
+    }
+
+
+def count_unchecked_by_phase(
+    plan_path: str, automated_only: bool = False
+) -> dict[str, tuple[int, bool]]:
+    return {
+        phase_name: (len(unchecked_lines), has_checked)
+        for phase_name, (unchecked_lines, has_checked) in _collect_phase_data(
+            plan_path, automated_only=automated_only
+        ).items()
+    }
+
+
+def unchecked_items_by_phase(
+    plan_path: str, automated_only: bool = False
+) -> dict[str, list[str]]:
+    return {
+        phase_name: unchecked_lines[:]
+        for phase_name, (unchecked_lines, _has_checked) in _collect_phase_data(
+            plan_path, automated_only=automated_only
+        ).items()
+    }
+
+
+def create_marker(session_id: str, plan_path: str) -> None:
+    marker = marker_path(session_id)
+    payload = {
+        "plan_path": str(Path(plan_path).resolve()),
+        "created_at": datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+    }
+
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        return
+
+
+def is_plan_file(file_path: str) -> bool:
+    if not file_path:
+        return False
+
+    path = Path(file_path)
+    return "thoughts" in {part.lower() for part in path.parts}
+
+
+def should_throttle(session_id: str, interval_seconds: int = 120) -> bool:
+    if not session_id:
+        return False
+
+    throttle_file = Path("/tmp") / f".plan-reminder-{_safe_session_id(session_id)}"
+    now = time.time()
+    last_value: float | None = None
+
+    try:
+        last_value = float(throttle_file.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        last_value = None
+
+    if last_value is not None and (now - last_value) < interval_seconds:
+        return True
+
+    try:
+        throttle_file.write_text(str(now), encoding="utf-8")
+    except OSError:
+        return False
+
+    return False
+
+
+__all__ = [
+    "count_unchecked_by_phase",
+    "count_unchecked_items",
+    "create_marker",
+    "find_active_plan",
+    "is_plan_file",
+    "marker_exists",
+    "marker_path",
+    "should_throttle",
+    "unchecked_items_by_phase",
+]

--- a/cc-plugin/base/skills/implementing/SKILL.md
+++ b/cc-plugin/base/skills/implementing/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: implementing
 description: Plan implementation skill. Executes approved technical plans phase by phase with verification checkpoints.
+hooks:
+  PostToolUse:
+    - matcher: "Edit|Write"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/plan_checkbox_reminder.py"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/plan_checkbox_stop.py"
 ---
 
 # Implementing
@@ -91,10 +101,11 @@ Store these preferences and apply them throughout the implementation.
 When given a plan path:
 1. Read the plan completely
 2. Check for existing checkmarks (`- [x]`)
-3. **Read files fully** - never use limit/offset parameters
-4. Think deeply about how the pieces fit together
-5. Create a todo list to track progress
-6. Start implementing if you understand what needs to be done
+3. Set plan status to `status: in-progress` by editing the frontmatter `status` field. This signals to progress-tracking hooks which plan is active.
+4. **Read files fully** - never use limit/offset parameters
+5. Think deeply about how the pieces fit together
+6. Create a todo list to track progress
+7. Start implementing if you understand what needs to be done
 
 If no plan path provided, ask for one.
 
@@ -160,5 +171,12 @@ If the plan has existing checkmarks:
 - Trust that completed work is done
 - Pick up from the first unchecked item
 - Verify previous work only if something seems off
+
+## Completing Implementation
+
+When all phases are complete and verified:
+1. Set the plan frontmatter `status` field to `completed`.
+2. Ensure automated verification checkboxes are updated.
+3. Leave manual verification checkboxes unchecked until the user confirms completion.
 
 Remember: You're implementing a solution, not just checking boxes. Keep the end goal in mind.

--- a/thoughts/taras/plans/2026-02-19-plan-checkbox-hook.md
+++ b/thoughts/taras/plans/2026-02-19-plan-checkbox-hook.md
@@ -1,0 +1,270 @@
+---
+date: 2026-02-19T00:00:00Z
+topic: "Plan Checkbox Hook Implementation"
+author: Claude
+status: in-progress
+autonomy: critical
+tags: [plan, claude-code, hooks, cc-plugin, plan-tracking]
+---
+
+# Plan Checkbox Hook Implementation
+
+## Overview
+
+Implement two Python hook scripts in `cc-plugin/base/hooks/` that remind and enforce plan checkbox updates during implementation sessions. The hooks are scoped to the implementing skill via YAML frontmatter, so they only fire when that skill is active.
+
+## Current State Analysis
+
+- The implementing skill (`cc-plugin/base/skills/implementing/SKILL.md`) has instructions telling Claude to check off plan items, but these are markdown instructions that get forgotten during long sessions.
+- There is one existing hook: `cc-plugin/base/hooks/validate-thoughts.py` (PreToolUse, Python).
+- Plugin manifest at `cc-plugin/base/.claude-plugin/plugin.json` has one PreToolUse hook entry.
+- No PostToolUse or Stop hooks exist anywhere in the plugin.
+- Plans use `- [ ]` / `- [x]` checkbox format in Success Criteria sections.
+- Plan frontmatter has a `status` field that can be set to `in-progress`.
+
+### Key Discoveries:
+- Skill-scoped hooks are defined in SKILL.md YAML frontmatter and only fire when that skill is active (`cc-plugin/base/skills/implementing/SKILL.md:1-4`)
+- Hook scripts receive `session_id` in stdin JSON, enabling lazy marker file creation without the skill needing to know the session_id
+- `${CLAUDE_PLUGIN_ROOT}` resolves to the plugin root directory in hook commands
+- PostToolUse hooks can return `additionalContext` to inject messages back to Claude
+- Stop hooks use `decision: "block"` + `reason` and support `stop_hook_active` to prevent infinite loops
+
+## Desired End State
+
+1. **PostToolUse hook** fires after Edit/Write during implementation, gently reminding Claude to check off completed plan items (throttled to every 2 minutes)
+2. **Stop hook** blocks Claude's first stop attempt if unchecked **automated verification** items remain (manual verification items are excluded since they require human interaction)
+3. Both hooks use a marker file at `~/.claude/active-plans/<session_id>.json` for fast plan lookup (lazy-created on first invocation)
+4. The implementing skill sets `status: in-progress` in the plan frontmatter at start and `status: completed` at end
+5. Hooks only fire during implementing skill sessions (skill-scoped frontmatter)
+
+## Quick Verification Reference
+
+Common commands to verify the implementation:
+- `python3 cc-plugin/base/hooks/plan_utils.py` (module self-test if we add one)
+- `echo '{"session_id":"test","cwd":"/tmp","hook_event_name":"PostToolUse","tool_name":"Edit","tool_input":{"file_path":"/tmp/test.py"}}' | python3 cc-plugin/base/hooks/plan_checkbox_reminder.py` (manual hook test)
+- `echo '{"session_id":"test","cwd":"/tmp","hook_event_name":"Stop","stop_hook_active":false}' | python3 cc-plugin/base/hooks/plan_checkbox_stop.py` (manual hook test)
+
+Key files to check:
+- `cc-plugin/base/hooks/plan_utils.py` (shared utilities)
+- `cc-plugin/base/hooks/plan_checkbox_reminder.py` (PostToolUse hook)
+- `cc-plugin/base/hooks/plan_checkbox_stop.py` (Stop hook)
+- `cc-plugin/base/skills/implementing/SKILL.md` (frontmatter + status management)
+
+## What We're NOT Doing
+
+- **Not adding plugin.json hooks** — hooks are scoped to the implementing skill via SKILL.md frontmatter, not registered globally
+- **Not using LLM-based hooks** — command type hooks (Python scripts) are sufficient
+- **Not handling subagent tool calls** — open question from research, out of scope for v1
+- **Not adding SessionEnd cleanup** — marker files are tiny and keyed by session_id; can add cleanup later if needed
+- **Not modifying the planning skill** — only the implementing skill gets hooks
+
+## Implementation Approach
+
+Two complementary mechanisms:
+1. **PostToolUse reminder** (gentle): After code edits, inject a context message reminding Claude to check off plan items. Time-throttled to avoid noise.
+2. **Stop enforcement** (firm but scoped): When Claude tries to stop, block once if unchecked **automated verification** items remain. Manual verification items are excluded since they require human interaction and are expected to be unchecked when pausing between phases. Allow on second attempt to prevent infinite loops.
+
+Both share common logic via `plan_utils.py`: finding the active plan (marker file → frontmatter scan fallback), counting unchecked items, and managing the marker file lifecycle.
+
+---
+
+## Phase 1: Hook Scripts
+
+### Overview
+Create three Python files in `cc-plugin/base/hooks/`: shared utilities, PostToolUse reminder hook, and Stop enforcement hook.
+
+### Changes Required:
+
+#### 1. Shared Utilities
+**File**: `cc-plugin/base/hooks/plan_utils.py` (new)
+**Changes**: Create module with shared functions:
+
+- `find_active_plan(session_id: str, cwd: str) -> str | None`
+  - Check marker file at `~/.claude/active-plans/<session_id>.json`
+  - If no marker: scan `<cwd>/thoughts/` recursively for files with `status: in-progress` in YAML frontmatter
+  - If found via scan: create marker file for future fast lookup
+  - Return absolute path to plan file, or None
+- `count_unchecked_items(plan_path: str, automated_only: bool = False) -> tuple[int, list[str]]`
+  - Returns `(count, unchecked_lines)` — count of unchecked items plus the actual text lines for display in the reminder
+  - If `automated_only=False`: count ALL lines matching `^\s*- \[ \]` in the plan file
+  - If `automated_only=True`: only count unchecked items under `#### Automated Verification:` sections (stop counting at the next `####` heading or `---` separator)
+  - This distinction matters: the PostToolUse reminder counts all items (broad reminder), while the Stop hook only enforces automated items (manual items require human interaction)
+  - Parser is a simple line-by-line state machine: toggle `in_automated_section` flag on/off when hitting `#### Automated Verification:` / next `####`/`###`/`##`/`---` heading
+  - Note: some older plans lack `####` subheadings — handled gracefully (0 automated items)
+- `count_unchecked_by_phase(plan_path: str, automated_only: bool = False) -> dict[str, tuple[int, bool]]`
+  - Returns per-phase data: `{phase_name: (unchecked_count, has_any_checked)}`
+  - Parses `## Phase N: Name` headings to identify phase boundaries
+  - `has_any_checked` is True if the phase has at least one `- [x]` item (any section, not just automated)
+  - **Phase-started heuristic**: a phase is considered "started" if:
+    1. It is **Phase 1** and a marker file exists for this session (covers the cold-start case — implementation just began, nothing checked yet), OR
+    2. It has at least one `[x]` item (any section, automated or manual)
+  - Only started phases are enforced by the Stop hook. Future phases (all `[ ]` and not Phase 1) are skipped.
+  - The PostToolUse reminder uses the total count across all phases (no phase filtering)
+  - The Stop hook calls this with `automated_only=True` and sums unchecked items only from started phases
+- `create_marker(session_id: str, plan_path: str) -> None`
+  - Create `~/.claude/active-plans/<session_id>.json` with `{"plan_path": "<abs-path>", "created_at": "<ISO-8601>"}`
+  - Create directory if it doesn't exist
+- `is_plan_file(file_path: str) -> bool`
+  - Check if the file path is inside a `thoughts/` directory (skip reminders when editing the plan itself)
+- `should_throttle(session_id: str, interval_seconds: int = 120) -> bool`
+  - Check `/tmp/.plan-reminder-<session_id>` timestamp
+  - Return True if last reminder was less than `interval_seconds` ago
+  - Update timestamp file when returning False
+
+#### 2. PostToolUse Reminder Hook
+**File**: `cc-plugin/base/hooks/plan_checkbox_reminder.py` (new)
+**Changes**: Create PostToolUse hook script:
+
+- Read stdin JSON
+- Extract `session_id`, `cwd`, `tool_input.file_path`
+- Skip if editing a plan/thoughts file (`is_plan_file()`)
+- Skip if throttled (`should_throttle()`)
+- Find active plan (`find_active_plan()`)
+- Count unchecked items (`count_unchecked_items()`)
+- If unchecked > 0: output JSON with `hookSpecificOutput.additionalContext` reminder
+- Exit 0 in all cases (never block)
+
+#### 3. Stop Enforcement Hook
+**File**: `cc-plugin/base/hooks/plan_checkbox_stop.py` (new)
+**Changes**: Create Stop hook script:
+
+- Read stdin JSON
+- Extract `session_id`, `cwd`, `stop_hook_active`
+- If `stop_hook_active` is true: exit 0 (allow stop, prevent infinite loop)
+- Find active plan (`find_active_plan()`)
+- Get per-phase unchecked automated items (`count_unchecked_by_phase(automated_only=True)`)
+- Filter to only "started" phases (phases with at least one `[x]` item — future phases are skipped)
+- Sum unchecked automated items across started phases
+- If sum > 0: output JSON with `decision: "block"` and `reason` listing the plan file and which automated items in started phases are unchecked
+- If sum == 0: exit 0 (allow stop — manual items and future-phase items don't block)
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Files exist: `ls cc-plugin/base/hooks/plan_utils.py cc-plugin/base/hooks/plan_checkbox_reminder.py cc-plugin/base/hooks/plan_checkbox_stop.py`
+- [x] Scripts are executable: `test -x cc-plugin/base/hooks/plan_checkbox_reminder.py && test -x cc-plugin/base/hooks/plan_checkbox_stop.py && echo OK`
+- [x] Python syntax valid: `python3 -c "import py_compile; py_compile.compile('cc-plugin/base/hooks/plan_utils.py', doraise=True); py_compile.compile('cc-plugin/base/hooks/plan_checkbox_reminder.py', doraise=True); py_compile.compile('cc-plugin/base/hooks/plan_checkbox_stop.py', doraise=True); print('OK')"`
+- [x] PostToolUse hook returns empty on non-plan edit (no active plan): `echo '{"session_id":"test123","cwd":"/tmp","hook_event_name":"PostToolUse","tool_name":"Edit","tool_input":{"file_path":"/tmp/test.py"}}' | python3 cc-plugin/base/hooks/plan_checkbox_reminder.py; echo "exit: $?"`
+- [x] Stop hook allows stop when no active plan: `echo '{"session_id":"test123","cwd":"/tmp","hook_event_name":"Stop","stop_hook_active":false}' | python3 cc-plugin/base/hooks/plan_checkbox_stop.py; echo "exit: $?"`
+- [x] Stop hook allows stop when stop_hook_active is true: `echo '{"session_id":"test123","cwd":"/tmp","hook_event_name":"Stop","stop_hook_active":true}' | python3 cc-plugin/base/hooks/plan_checkbox_stop.py; echo "exit: $?"`
+
+#### Manual Verification:
+- [ ] Create a test plan with `status: in-progress` and unchecked items, verify PostToolUse hook returns reminder JSON
+- [ ] Verify Stop hook blocks with unchecked automated verification items and returns proper JSON
+- [ ] Verify Stop hook allows stop when only manual verification items are unchecked
+- [ ] Verify time-based throttling works (second invocation within 2 min returns nothing)
+- [ ] Verify marker file is created at `~/.claude/active-plans/test123.json` after first invocation
+
+**Implementation Note**: After completing this phase, pause for manual verification. Test scripts with mock JSON input before proceeding to skill integration.
+
+---
+
+## Phase 2: Skill Integration
+
+### Overview
+Add hook frontmatter to the implementing skill's SKILL.md and add instructions for managing plan `status` field.
+
+### Changes Required:
+
+#### 1. SKILL.md Frontmatter Hooks
+**File**: `cc-plugin/base/skills/implementing/SKILL.md`
+**Changes**: Add hooks to the YAML frontmatter:
+
+```yaml
+---
+name: implementing
+description: Plan implementation skill. Executes approved technical plans phase by phase with verification checkpoints.
+hooks:
+  PostToolUse:
+    - matcher: "Edit|Write"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/plan_checkbox_reminder.py"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/plan_checkbox_stop.py"
+---
+```
+
+#### 2. Status Management Instructions
+**File**: `cc-plugin/base/skills/implementing/SKILL.md`
+**Changes**: Add to the "Getting Started" section (after step 2 "Check for existing checkmarks"):
+
+Add a new step: "Set plan status to `in-progress` by editing the frontmatter `status` field. This signals to progress-tracking hooks which plan is active."
+
+Add to the end of the skill (after "Resuming Work" section): a "Completing Implementation" section instructing Claude to set `status: completed` when all phases are done and verified.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] SKILL.md has valid YAML frontmatter: `python3 -c "import yaml; f=open('cc-plugin/base/skills/implementing/SKILL.md'); content=f.read(); fm=content.split('---')[1]; yaml.safe_load(fm); print('OK')"` (validated via `ruby -e "require 'yaml'; content = File.read('cc-plugin/base/skills/implementing/SKILL.md'); fm = content.split('---')[1]; YAML.safe_load(fm); puts 'OK'"` because this environment's `python3` lacks PyYAML)
+- [x] Frontmatter includes PostToolUse hook: `grep -q 'PostToolUse' cc-plugin/base/skills/implementing/SKILL.md && echo OK`
+- [x] Frontmatter includes Stop hook: `grep -q 'Stop:' cc-plugin/base/skills/implementing/SKILL.md && echo OK`
+- [x] Status management instructions present: `grep -q 'status: in-progress' cc-plugin/base/skills/implementing/SKILL.md && echo OK`
+- [x] Hook commands reference correct paths: `grep -q 'plan_checkbox_reminder.py' cc-plugin/base/skills/implementing/SKILL.md && grep -q 'plan_checkbox_stop.py' cc-plugin/base/skills/implementing/SKILL.md && echo OK`
+
+#### Manual Verification:
+- [ ] Review the SKILL.md diff to confirm frontmatter is well-formed and doesn't break the skill's existing content
+- [ ] Verify `${CLAUDE_PLUGIN_ROOT}` resolves correctly by checking the plugin's installed path
+- [ ] Review the status management instructions for clarity
+
+**Implementation Note**: After completing this phase, pause for manual confirmation before proceeding to E2E testing.
+
+---
+
+## Phase 3: Manual E2E Testing
+
+### Overview
+End-to-end verification using a real implementation session.
+
+### Test Plan:
+
+1. **Setup**: Create a test plan file at `thoughts/taras/plans/2026-02-19-test-checkbox-hook.md` with:
+   - Frontmatter with `status: approved`
+   - A few phases with `- [ ]` checkbox items
+
+2. **Invoke implementing skill**: Run `/implement-plan thoughts/taras/plans/2026-02-19-test-checkbox-hook.md`
+
+3. **Verify status update**: Check that the skill changes `status: approved` → `status: in-progress`
+
+4. **Verify PostToolUse reminder**: Make a code edit and observe if the reminder appears in the context (may need verbose mode `Ctrl+O`)
+
+5. **Verify Stop hook**: Try to finish the session and observe if it blocks with unchecked items
+
+6. **Verify throttling**: Make multiple edits in quick succession, confirm reminder only appears once per 2-minute window
+
+7. **Cleanup**: Remove test plan file
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] No stale marker files in `~/.claude/active-plans/`: `ls ~/.claude/active-plans/ 2>/dev/null | wc -l`
+
+#### Manual Verification:
+- [ ] PostToolUse reminder fires after code edit during implementation
+- [ ] Reminder does NOT fire when editing the plan file itself
+- [ ] Stop hook blocks first stop attempt when unchecked automated verification items exist
+- [ ] Stop hook allows stop when only manual verification items are unchecked (e.g., between-phase pause)
+- [ ] Stop hook allows second stop attempt (stop_hook_active=true)
+- [ ] Time-based throttling limits reminders to ~2 minute intervals
+- [ ] Marker file created at `~/.claude/active-plans/<session_id>.json`
+- [ ] Plan status set to `in-progress` at start of implementation
+
+**Implementation Note**: This phase is entirely manual. If `${CLAUDE_PLUGIN_ROOT}` doesn't resolve in skill frontmatter, fall back to using a relative path from the skill file or an absolute path pattern.
+
+---
+
+## Testing Strategy
+
+- **Unit testing**: Manual testing with mock JSON piped to stdin (Phase 1)
+- **Integration testing**: YAML frontmatter validation (Phase 2)
+- **E2E testing**: Real implementation session with a test plan (Phase 3)
+
+## References
+- Research document: `thoughts/taras/research/2026-02-19-plan-checkbox-hook.md`
+- Existing hook pattern: `cc-plugin/base/hooks/validate-thoughts.py`
+- Implementing skill: `cc-plugin/base/skills/implementing/SKILL.md`
+- Plugin manifest: `cc-plugin/base/.claude-plugin/plugin.json`
+- Claude Code hooks docs: https://code.claude.com/docs/en/hooks.md
+- Claude Code hooks guide: https://code.claude.com/docs/en/hooks-guide.md

--- a/thoughts/taras/research/2026-02-19-plan-checkbox-hook.md
+++ b/thoughts/taras/research/2026-02-19-plan-checkbox-hook.md
@@ -1,0 +1,346 @@
+---
+date: 2026-02-19T00:00:00Z
+topic: "Plan Checkbox Hook for cc-plugin/base"
+author: Claude
+status: draft
+tags: [research, claude-code, hooks, cc-plugin, plan-tracking]
+---
+
+# Research: Plan Checkbox Hook for cc-plugin/base
+
+## Goal
+
+Implement a hook in `cc-plugin/base` that reminds/instructs the agent to check off completed items (`- [ ]` → `- [x]`) in the plan file it's working on after completing implementation steps.
+
+## Current State
+
+### Existing Hook Infrastructure
+
+The plugin (`cc-plugin/base`) currently has **exactly one hook** registered in `.claude-plugin/plugin.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-thoughts.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This `validate-thoughts.py` hook:
+- Fires before `Write` or `Edit` tool calls
+- Only acts on files inside `thoughts/` directory
+- Validates path format and frontmatter structure
+- Uses **exit code 2 + stderr** to block and inject corrective messages back to Claude
+
+There are **no** `PostToolUse`, `Stop`, `TaskCompleted`, or any other hook types registered.
+
+### How the Implementing Skill Tracks Progress
+
+The `skills/implementing/SKILL.md` already instructs Claude to:
+1. Read the plan completely and check for existing `- [x]` checkmarks
+2. Create a TodoWrite list for in-session tracking
+3. After each phase, check off items via `Edit` tool calls
+4. Resume from the first unchecked item if rejoining a session
+
+**The problem**: These are _instructions in the skill markdown_, not enforced behavior. The agent can (and does) forget to check off boxes, especially during long implementation sessions or when focused on fixing issues.
+
+### Plan File Format
+
+Plans follow a consistent structure:
+- YAML frontmatter with `status`, `date`, `topic`, `autonomy` fields
+- Phases with `## Phase N: Name` headings
+- Per-phase `### Success Criteria:` with checkbox items (`- [ ]` / `- [x]`)
+- End-of-plan verification sections with checkboxes
+- Rollout checklists with checkboxes
+
+Checkbox patterns found:
+```markdown
+- [ ] `bun tsc --noEmit` passes          # Unchecked
+- [x] `uv sync` runs without errors       # Checked
+```
+
+## Claude Code Hook System
+
+### Available Hook Events (14 total)
+
+| Event | Matcher Support | Key Use |
+|-------|----------------|---------|
+| `SessionStart` | `startup`, `resume`, `clear`, `compact` | Initial context injection |
+| `UserPromptSubmit` | No | Augment user prompts |
+| `PreToolUse` | Tool names (`Edit`, `Write`, `Bash`, etc.) | Gate/validate tool calls |
+| `PermissionRequest` | Tool names | Auto-approve/deny |
+| **`PostToolUse`** | **Tool names** | **React after tool execution** |
+| `PostToolUseFailure` | Tool names | React to failures |
+| `Notification` | Notification types | React to notifications |
+| `SubagentStart` / `SubagentStop` | Agent types | Subagent lifecycle |
+| **`Stop`** | **No** | **Prevent agent from stopping** |
+| `TeammateIdle` | No | Multi-agent coordination |
+| **`TaskCompleted`** | **No** | **React to task completion** |
+| `PreCompact` | `manual`, `auto` | Before context compaction |
+| `SessionEnd` | End reasons | Session cleanup |
+
+### Hook Handler Types
+
+1. **Command** (`type: "command"`): Shell script, receives JSON on stdin
+2. **Prompt** (`type: "prompt"`): Single-turn LLM evaluation
+3. **Agent** (`type: "agent"`): Multi-turn LLM agent with tool access (up to 50 turns)
+
+### How Hooks Can Inject Messages
+
+| Event | Injection Mechanism |
+|-------|-------------------|
+| `PreToolUse` | `additionalContext` in `hookSpecificOutput` (exit 0) or stderr (exit 2 to block) |
+| **`PostToolUse`** | **`additionalContext` field — fed back to Claude after tool completes** |
+| `UserPromptSubmit` | `additionalContext` or plain stdout |
+| `SessionStart` | `additionalContext` |
+| `SubagentStart` | `additionalContext` |
+| `Stop` | `decision: "block"` with reason — **strictly block/allow, no informational-only mode** |
+| Async hooks | `systemMessage` (shown on next turn) or `additionalContext` |
+
+### Key Finding: Skill-Scoped Hooks (Frontmatter)
+
+**Hooks can be defined directly in a skill's YAML frontmatter.** These hooks:
+- Only fire when that skill is active
+- Are automatically cleaned up when the skill finishes
+- Eliminate the need for session detection or marker files
+
+```yaml
+---
+name: my-skill
+hooks:
+  PostToolUse:
+    - matcher: "Edit|Write"
+      hooks:
+        - type: command
+          command: "./hooks/my-hook.sh"
+---
+```
+
+This is the cleanest solution for scoping hooks to the implementing skill only.
+
+### Stop Hook Behavior (Detailed)
+
+- `decision: "block"` + `reason` prevents Claude from stopping; reason is shown to Claude as instruction to continue
+- **No informational-only mode** — Stop hooks are strictly block/allow
+- **Block-once pattern is possible**: Use a counter file + `stop_hook_active` field to block first attempt, allow second
+- `stop_hook_active` field in input tells you if Claude is already continuing from a previous stop hook block (prevents infinite loops)
+- `additionalContext` is **NOT** available for Stop hooks — only `decision` and `reason`
+
+### Hook Input Data (stdin JSON)
+
+All hooks receive:
+```json
+{
+  "session_id": "...",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "cwd": "/current/working/dir",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUse"
+}
+```
+
+`PostToolUse` additionally receives: `tool_name`, `tool_input`, `tool_response`, `tool_use_id`.
+`Stop` receives: `stop_hook_active`, `last_assistant_message`.
+
+### Session Detection Limitations
+
+- **No built-in way** for a hook to know which skill is currently active
+- `transcript_path` could be parsed to find skill invocation markers, but this is fragile
+- The hook system intentionally provides minimal environmental context
+- **Solution: Use skill-scoped frontmatter hooks** (see above) — they inherently only fire when the skill is active
+
+## Recommended Approach
+
+### Architecture: Skill-Scoped PostToolUse + Stop Hook with Marker File
+
+Two complementary mechanisms working together:
+
+#### 1. Skill-Scoped PostToolUse Hook (Gentle Reminders)
+
+Define a `PostToolUse` hook **in the implementing skill's SKILL.md frontmatter**. This eliminates the session detection problem entirely — the hook only fires when the implementing skill is active.
+
+The hook:
+- Fires after `Edit` or `Write` tool calls
+- Reads a marker file at `~/.claude/active-plans/<session_id>.json` to find the active plan
+- Skips if the edited file IS the plan file (already updating it)
+- Uses **time-based throttling** (remind every ~2 minutes, not every edit)
+- Also scans for plans with `status: in-progress` in frontmatter as fallback
+- Returns `additionalContext` with a gentle reminder
+
+#### 2. Skill-Scoped Stop Hook (Block-Once Enforcement)
+
+Define a `Stop` hook in the same skill frontmatter. When Claude tries to stop:
+- First time: Check plan for unchecked items, **block** with reason explaining what to check off
+- Second time (`stop_hook_active: true`): Allow Claude to stop (prevents infinite loops)
+
+This gives enforcement without being obnoxious.
+
+#### 3. Marker File at `~/.claude/active-plans/`
+
+- **Location**: `~/.claude/active-plans/<session_id>.json` — avoids git pollution, supports multiple concurrent implementations
+- **Written by**: Implementing skill at start of implementation
+- **Content**: `{ "plan_path": "/absolute/path/to/plan.md", "started_at": "ISO-8601" }`
+- **Cleaned up by**: Implementing skill on completion + `SessionEnd` hook as safety net
+
+### Why This Approach
+
+1. **Skill-scoped hooks** solve the "only during implementation" problem cleanly — no session parsing needed
+2. **Marker file in `~/.claude/`** avoids git pollution and supports multiple repos (per Taras's feedback)
+3. **Time-based throttling** over count-based (per Taras's feedback)
+4. **Frontmatter scanning** (`status: in-progress`) as fallback alongside marker file (per Taras's feedback)
+5. **Non-blocking reminders** (PostToolUse) + **one-time enforcement** (Stop) covers both gentle and firm nudges
+6. **Lightweight** — bash scripts, not LLM agents
+
+### Implementation Sketch
+
+#### Implementing Skill Frontmatter Addition
+
+```yaml
+---
+# ... existing frontmatter ...
+hooks:
+  PostToolUse:
+    - matcher: "Edit|Write"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/plan-checkbox-reminder.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/plan-checkbox-stop.sh"
+---
+```
+
+#### PostToolUse Hook (`plan-checkbox-reminder.sh`)
+
+```bash
+#!/bin/bash
+# hooks/plan-checkbox-reminder.sh
+# Gentle reminder to check off plan items after code edits
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+
+# Skip if editing a plan file directly (already working on it)
+if [[ "$FILE_PATH" == *"/thoughts/"* ]]; then
+  exit 0
+fi
+
+# Find active plan via marker file
+MARKER="$HOME/.claude/active-plans/${SESSION_ID}.json"
+PLAN_FILE=""
+if [[ -f "$MARKER" ]]; then
+  PLAN_FILE=$(jq -r '.plan_path // ""' "$MARKER")
+fi
+
+# Fallback: scan for in-progress plans via frontmatter
+if [[ -z "$PLAN_FILE" || ! -f "$PLAN_FILE" ]]; then
+  CWD=$(echo "$INPUT" | jq -r '.cwd // ""')
+  PLAN_FILE=$(grep -rl '^status: in-progress' "$CWD/thoughts/" 2>/dev/null | head -1)
+fi
+
+if [[ -z "$PLAN_FILE" || ! -f "$PLAN_FILE" ]]; then
+  exit 0
+fi
+
+# Count unchecked items
+UNCHECKED=$(grep -c '^\s*- \[ \]' "$PLAN_FILE" 2>/dev/null || echo 0)
+if [[ "$UNCHECKED" -eq 0 ]]; then
+  exit 0
+fi
+
+# Time-based throttle: remind at most every 2 minutes
+THROTTLE_FILE="/tmp/.plan-reminder-${SESSION_ID}"
+NOW=$(date +%s)
+LAST_REMINDER=$(cat "$THROTTLE_FILE" 2>/dev/null || echo 0)
+ELAPSED=$((NOW - LAST_REMINDER))
+
+if [[ "$ELAPSED" -lt 120 ]]; then
+  exit 0
+fi
+
+echo "$NOW" > "$THROTTLE_FILE"
+
+# Return reminder as additionalContext
+PLAN_BASENAME=$(basename "$PLAN_FILE")
+jq -n --arg plan "$PLAN_BASENAME" --arg path "$PLAN_FILE" --arg count "$UNCHECKED" '{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": ("PLAN PROGRESS REMINDER: You are implementing plan \"" + $plan + "\" (" + $path + "). There are " + $count + " unchecked items. After completing a phase or significant task, check off completed items (change `- [ ]` to `- [x]`) in the plan file.")
+  }
+}'
+```
+
+#### Stop Hook (`plan-checkbox-stop.sh`)
+
+```bash
+#!/bin/bash
+# hooks/plan-checkbox-stop.sh
+# Block first stop attempt if plan has unchecked items
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
+
+# If already blocked once, allow stop (prevent infinite loop)
+if [[ "$STOP_HOOK_ACTIVE" == "true" ]]; then
+  exit 0
+fi
+
+# Find active plan
+MARKER="$HOME/.claude/active-plans/${SESSION_ID}.json"
+PLAN_FILE=""
+if [[ -f "$MARKER" ]]; then
+  PLAN_FILE=$(jq -r '.plan_path // ""' "$MARKER")
+fi
+
+if [[ -z "$PLAN_FILE" || ! -f "$PLAN_FILE" ]]; then
+  exit 0
+fi
+
+# Count unchecked items
+UNCHECKED=$(grep -c '^\s*- \[ \]' "$PLAN_FILE" 2>/dev/null || echo 0)
+if [[ "$UNCHECKED" -eq 0 ]]; then
+  exit 0
+fi
+
+# Block: remind to check off items
+jq -n --arg plan "$PLAN_FILE" --arg count "$UNCHECKED" '{
+  "decision": "block",
+  "reason": ("Before finishing, please update the plan file at " + $plan + ". There are " + $count + " unchecked items. Check off any items you have completed (change `- [ ]` to `- [x]`), then you can finish.")
+}'
+```
+
+## Discarded Approaches
+
+| Approach | Why Discarded |
+|----------|--------------|
+| TaskCompleted hook | Per Taras: "noup" — depends on TodoWrite usage which isn't enforced |
+| Agent hook (LLM-based) | Overkill — too expensive and slow for a reminder |
+| Plugin-level hook (plugin.json) | Would fire in all sessions, not just implementation |
+| `${CWD}/.claude/.active-plan` marker | Git pollution risk, doesn't support multiple repos (per Taras) |
+| Count-based throttling | Time-based is more predictable (per Taras) |
+
+## Open Questions
+
+1. **Subagent awareness**: If the implementing skill delegates to subagents, do PostToolUse hooks from skill frontmatter fire for subagent tool calls? (Needs testing)
+2. **Frontmatter hook support for `${CLAUDE_PLUGIN_ROOT}`**: Does the `${CLAUDE_PLUGIN_ROOT}` variable resolve correctly when hooks are defined in skill frontmatter vs plugin.json? May need to use a relative path or absolute path instead.
+3. **Marker file cleanup**: SessionEnd hook as safety net, or rely on the implementing skill's own cleanup?
+
+## References
+
+- Hook docs: https://code.claude.com/docs/en/hooks.md
+- Hook guide: https://code.claude.com/docs/en/hooks-guide.md
+- Existing hook: `cc-plugin/base/hooks/validate-thoughts.py`
+- Implementing skill: `cc-plugin/base/skills/implementing/SKILL.md`
+- Plugin manifest: `cc-plugin/base/.claude-plugin/plugin.json`
+- ai-tracker PostToolUse example: `ai-tracker/src/ai_tracker/hooks/log_claude_edit.py`


### PR DESCRIPTION
## Summary
- add plan checkbox reminder and stop hooks for implementing sessions
- add shared plan hook utilities and throttling/phase parsing logic
- wire skill-scoped PostToolUse/Stop hooks in implementing SKILL frontmatter
- include plan/research thoughts documents and bump desplega plugin version to 1.4.2

## Testing
- python syntax checks for new hook scripts
- hook stdin smoke tests for reminder and stop behaviors
- frontmatter hook presence checks in implementing SKILL
- fallback YAML parse verification via Ruby (python env lacks PyYAML)
- marker directory stale-count check