### PR TITLE
file-review v1.8.0: tabs + mermaid + copy button

### DIFF
--- a/file-review/bun.lock
+++ b/file-review/bun.lock
@@ -16,6 +16,7 @@
         "codemirror": "^6.0.1",
         "highlight.js": "^11.11.1",
         "marked": "^17.0.1",
+        "mermaid": "^11",
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -26,6 +27,20 @@
     },
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@12.0.0", "", { "dependencies": { "@chevrotain/gast": "12.0.0", "@chevrotain/types": "12.0.0" } }, "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg=="],
+
+    "@chevrotain/gast": ["@chevrotain/gast@12.0.0", "", { "dependencies": { "@chevrotain/types": "12.0.0" } }, "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ=="],
+
+    "@chevrotain/regexp-to-ast": ["@chevrotain/regexp-to-ast@12.0.0", "", {}, "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@12.0.0", "", {}, "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA=="],
+
+    "@chevrotain/utils": ["@chevrotain/utils@12.0.0", "", {}, "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA=="],
+
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.0", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg=="],
 
     "@codemirror/commands": ["@codemirror/commands@6.10.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.4.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-uWDWFypNdQmz2y1LaNJzK7fL7TYKLeUAU0npEC685OKTF3KcQ2Vu3klIM78D7I6wGhktme0lh3CuQLv0ZCrD9Q=="],
@@ -100,6 +115,10 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.1", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "mlly": "^1.8.2" } }, "sha512-MwzoDtw9rO1x+qfgLTV/IVXsHDBqeYZoMIQC8SfxfYSlaSUG+oWiAcoiB1yajAda6mqblm4/1/w2E8tRu7a7Tw=="],
+
     "@lezer/common": ["@lezer/common@1.5.0", "", {}, "sha512-PNGcolp9hr4PJdXR4ix7XtixDrClScvtSCYW3rQG106oVMOOI+jFb+0+J3mbeL/53g1Zd6s0kJzaw6Ri68GmAA=="],
 
     "@lezer/css": ["@lezer/css@1.3.0", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw=="],
@@ -115,6 +134,8 @@
     "@lezer/markdown": ["@lezer/markdown@1.6.3", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw=="],
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
 
     "@replit/codemirror-vim": ["@replit/codemirror-vim@6.3.0", "", { "peerDependencies": { "@codemirror/commands": "6.x.x", "@codemirror/language": "6.x.x", "@codemirror/search": "6.x.x", "@codemirror/state": "6.x.x", "@codemirror/view": "6.x.x" } }, "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ=="],
 
@@ -198,13 +219,171 @@
 
     "@tauri-apps/plugin-fs": ["@tauri-apps/plugin-fs@2.4.5", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/marked": ["@types/marked@6.0.0", "", { "dependencies": { "marked": "*" } }, "sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "chevrotain": ["chevrotain@12.0.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "12.0.0", "@chevrotain/gast": "12.0.0", "@chevrotain/regexp-to-ast": "12.0.0", "@chevrotain/types": "12.0.0", "@chevrotain/utils": "12.0.0" } }, "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ=="],
+
+    "chevrotain-allstar": ["chevrotain-allstar@0.4.3", "", { "dependencies": { "lodash-es": "^4.18.1" }, "peerDependencies": { "chevrotain": "^12.0.0" } }, "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ=="],
+
     "codemirror": ["codemirror@6.0.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw=="],
 
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
+
+    "cytoscape": ["cytoscape@3.33.3", "", {}, "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
+    "dompurify": ["dompurify@3.4.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -212,32 +391,110 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "katex": ["katex@0.16.45", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "langium": ["langium@4.2.3", "", { "dependencies": { "@chevrotain/regexp-to-ast": "~12.0.0", "chevrotain": "~12.0.0", "chevrotain-allstar": "~0.4.3", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.1.0" } }, "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
+    "mermaid": ["mermaid@11.14.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "katex": "^0.16.25", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g=="],
+
+    "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
+
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rollup": ["rollup@4.55.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.55.1", "@rollup/rollup-android-arm64": "4.55.1", "@rollup/rollup-darwin-arm64": "4.55.1", "@rollup/rollup-darwin-x64": "4.55.1", "@rollup/rollup-freebsd-arm64": "4.55.1", "@rollup/rollup-freebsd-x64": "4.55.1", "@rollup/rollup-linux-arm-gnueabihf": "4.55.1", "@rollup/rollup-linux-arm-musleabihf": "4.55.1", "@rollup/rollup-linux-arm64-gnu": "4.55.1", "@rollup/rollup-linux-arm64-musl": "4.55.1", "@rollup/rollup-linux-loong64-gnu": "4.55.1", "@rollup/rollup-linux-loong64-musl": "4.55.1", "@rollup/rollup-linux-ppc64-gnu": "4.55.1", "@rollup/rollup-linux-ppc64-musl": "4.55.1", "@rollup/rollup-linux-riscv64-gnu": "4.55.1", "@rollup/rollup-linux-riscv64-musl": "4.55.1", "@rollup/rollup-linux-s390x-gnu": "4.55.1", "@rollup/rollup-linux-x64-gnu": "4.55.1", "@rollup/rollup-linux-x64-musl": "4.55.1", "@rollup/rollup-openbsd-x64": "4.55.1", "@rollup/rollup-openharmony-arm64": "4.55.1", "@rollup/rollup-win32-arm64-msvc": "4.55.1", "@rollup/rollup-win32-ia32-msvc": "4.55.1", "@rollup/rollup-win32-x64-gnu": "4.55.1", "@rollup/rollup-win32-x64-msvc": "4.55.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
+    "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
     "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
+    "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
+
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+
+    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "@tauri-apps/plugin-fs/@tauri-apps/api": ["@tauri-apps/api@2.9.1", "", {}, "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw=="],
+
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
   }
 }

--- a/file-review/index.html
+++ b/file-review/index.html
@@ -38,6 +38,7 @@
         </button>
       </div>
     </div>
+    <div id="tab-strip" class="tab-strip" role="tablist"></div>
     <div id="main-container">
       <div id="editor-container"></div>
       <div id="preview-wrapper" style="display: none; position: relative; flex: 7;">

--- a/file-review/package.json
+++ b/file-review/package.json
@@ -1,7 +1,7 @@
 {
   "name": "file-review",
   "private": true,
-  "version": "1.7.3",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev --",

--- a/file-review/package.json
+++ b/file-review/package.json
@@ -28,7 +28,8 @@
     "@tauri-apps/plugin-fs": "^2.4.5",
     "codemirror": "^6.0.1",
     "highlight.js": "^11.11.1",
-    "marked": "^17.0.1"
+    "marked": "^17.0.1",
+    "mermaid": "^11"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/file-review/src-tauri/Cargo.lock
+++ b/file-review/src-tauri/Cargo.lock
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "file-review"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "axum",
  "chrono",

--- a/file-review/src-tauri/Cargo.lock
+++ b/file-review/src-tauri/Cargo.lock
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "file-review"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "axum",
  "chrono",

--- a/file-review/src-tauri/Cargo.toml
+++ b/file-review/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file-review"
-version = "1.7.3"
+version = "1.8.0"
 description = "A Tauri application for reviewing and managing files."
 authors = ["contact@desplega.ai"]
 edition = "2021"

--- a/file-review/src-tauri/src/file_ops.rs
+++ b/file-review/src-tauri/src/file_ops.rs
@@ -5,6 +5,11 @@ use tauri::State;
 
 pub struct AppState {
     pub current_file: Mutex<Option<PathBuf>>,
+    /// All file paths supplied on the CLI (in order). Used by JS at startup
+    /// to open one tab per path. `current_file` mirrors the first path so the
+    /// existing single-file close-export flow keeps working until step-3
+    /// promotes it to multi-file. Empty if no file args were passed.
+    pub initial_files: Mutex<Vec<PathBuf>>,
     pub silent: bool,
     pub json_output: bool,
     pub stdin_mode: bool,
@@ -32,6 +37,18 @@ pub fn set_current_file(path: String, state: State<'_, AppState>) -> Result<(), 
 pub fn get_current_file(state: State<'_, AppState>) -> Option<String> {
     let current = state.current_file.lock().ok()?;
     current.as_ref().map(|p| p.to_string_lossy().to_string())
+}
+
+/// Return all file paths that were passed on the CLI. JS calls this at
+/// startup to open one tab per path. Empty if no file args.
+#[tauri::command]
+pub fn get_initial_files(state: State<'_, AppState>) -> Vec<String> {
+    state
+        .initial_files
+        .lock()
+        .ok()
+        .map(|v| v.iter().map(|p| p.to_string_lossy().to_string()).collect())
+        .unwrap_or_default()
 }
 
 #[tauri::command]

--- a/file-review/src-tauri/src/file_ops.rs
+++ b/file-review/src-tauri/src/file_ops.rs
@@ -3,13 +3,26 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::State;
 
+/// Snapshot of one open tab pushed from JS via `submit_tab_states`. Used
+/// by the close-window flow to dump comments from every open tab without
+/// re-reading from disk (which would miss unsaved buffer state).
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct TabState {
+    pub path: String,
+    /// Editor content with comment markers inlined — i.e., what
+    /// `serializeComments(tab.doc, tab.comments)` produced on the JS side.
+    pub content: String,
+}
+
 pub struct AppState {
     pub current_file: Mutex<Option<PathBuf>>,
     /// All file paths supplied on the CLI (in order). Used by JS at startup
-    /// to open one tab per path. `current_file` mirrors the first path so the
-    /// existing single-file close-export flow keeps working until step-3
-    /// promotes it to multi-file. Empty if no file args were passed.
+    /// to open one tab per path.
     pub initial_files: Mutex<Vec<PathBuf>>,
+    /// Snapshot of every currently-open tab pushed by JS. Source of truth
+    /// for the close-window comment-export flow when non-empty; falls
+    /// back to the single-file disk read when empty (e.g., web mode).
+    pub open_tabs: Mutex<Vec<TabState>>,
     pub silent: bool,
     pub json_output: bool,
     pub stdin_mode: bool,
@@ -49,6 +62,16 @@ pub fn get_initial_files(state: State<'_, AppState>) -> Vec<String> {
         .ok()
         .map(|v| v.iter().map(|p| p.to_string_lossy().to_string()).collect())
         .unwrap_or_default()
+}
+
+/// Replace the in-memory snapshot of open tabs. JS calls this on tab-close
+/// and window-close so the close-window handler can dump comments from
+/// every open tab.
+#[tauri::command]
+pub fn submit_tab_states(states: Vec<TabState>, state: State<'_, AppState>) {
+    if let Ok(mut open) = state.open_tabs.lock() {
+        *open = states;
+    }
 }
 
 #[tauri::command]

--- a/file-review/src-tauri/src/lib.rs
+++ b/file-review/src-tauri/src/lib.rs
@@ -157,13 +157,32 @@ pub fn run(
                             // Output comments if not silent
                             let state: tauri::State<'_, AppState> = app_handle.state();
                             if !state.silent {
-                                if let Some(file_path) = state.current_file.lock().ok().and_then(|f| f.clone()) {
-                                    if let Ok(content) = std::fs::read_to_string(&file_path) {
-                                        let comments = parse_comments_for_output(&content);
+                                let tab_snapshot: Vec<file_ops::TabState> = state
+                                    .open_tabs
+                                    .lock()
+                                    .ok()
+                                    .map(|t| t.clone())
+                                    .unwrap_or_default();
 
-                                        if state.stdin_mode {
-                                            // In stdin mode, always output file + content + comments
-                                            let file_path_str = file_path.to_string_lossy().to_string();
+                                if state.stdin_mode {
+                                    // Stdin mode is single-file by construction. Prefer the
+                                    // pushed in-memory tab content over a disk read so unsaved
+                                    // edits survive; fall back to disk if no tab was pushed.
+                                    if let Some(file_path) = state
+                                        .current_file
+                                        .lock()
+                                        .ok()
+                                        .and_then(|f| f.clone())
+                                    {
+                                        let file_path_str = file_path.to_string_lossy().to_string();
+                                        let content = tab_snapshot
+                                            .iter()
+                                            .find(|t| t.path == file_path_str)
+                                            .map(|t| t.content.clone())
+                                            .or_else(|| std::fs::read_to_string(&file_path).ok());
+
+                                        if let Some(content) = content {
+                                            let comments = parse_comments_for_output(&content);
                                             let modified = state
                                                 .original_content
                                                 .lock()
@@ -194,14 +213,77 @@ pub fn run(
                                                     )
                                                 );
                                             }
-                                        } else {
-                                            // Normal file mode - only output comments
-                                            if !comments.is_empty() {
-                                                if state.json_output {
-                                                    println!("{}", format_comments_json(&comments));
-                                                } else {
-                                                    println!("{}", format_comments_readable(&comments));
+                                        }
+                                    }
+                                } else if !tab_snapshot.is_empty() {
+                                    // Multi-tab mode: dump comments grouped per file. Single-tab
+                                    // sessions keep the existing flat output for backward compat
+                                    // with shell consumers that don't expect `## <path>` headers.
+                                    let single_tab = tab_snapshot.len() == 1;
+                                    if state.json_output {
+                                        let groups: Vec<serde_json::Value> = tab_snapshot
+                                            .iter()
+                                            .map(|t| {
+                                                let comments = parse_comments_for_output(&t.content);
+                                                serde_json::json!({
+                                                    "path": t.path,
+                                                    "comments": comments,
+                                                })
+                                            })
+                                            .filter(|g| {
+                                                g.get("comments")
+                                                    .and_then(|c| c.as_array())
+                                                    .map(|a| !a.is_empty())
+                                                    .unwrap_or(false)
+                                            })
+                                            .collect();
+
+                                        if single_tab {
+                                            if let Some(g) = groups.first() {
+                                                if let Some(comments) = g.get("comments") {
+                                                    println!("{}", comments);
                                                 }
+                                            }
+                                        } else if !groups.is_empty() {
+                                            println!(
+                                                "{}",
+                                                serde_json::to_string_pretty(&groups)
+                                                    .unwrap_or_default()
+                                            );
+                                        }
+                                    } else {
+                                        let mut sections: Vec<String> = Vec::new();
+                                        for tab in &tab_snapshot {
+                                            let comments = parse_comments_for_output(&tab.content);
+                                            if comments.is_empty() {
+                                                continue;
+                                            }
+                                            let body = format_comments_readable(&comments);
+                                            if single_tab {
+                                                sections.push(body);
+                                            } else {
+                                                sections.push(format!("## {}\n\n{}", tab.path, body));
+                                            }
+                                        }
+                                        if !sections.is_empty() {
+                                            println!("{}", sections.join("\n\n"));
+                                        }
+                                    }
+                                } else if let Some(file_path) = state
+                                    .current_file
+                                    .lock()
+                                    .ok()
+                                    .and_then(|f| f.clone())
+                                {
+                                    // Fallback: no tab snapshot was pushed (web mode, or JS
+                                    // crashed before pushing). Read active file from disk.
+                                    if let Ok(content) = std::fs::read_to_string(&file_path) {
+                                        let comments = parse_comments_for_output(&content);
+                                        if !comments.is_empty() {
+                                            if state.json_output {
+                                                println!("{}", format_comments_json(&comments));
+                                            } else {
+                                                println!("{}", format_comments_readable(&comments));
                                             }
                                         }
                                     }
@@ -217,6 +299,7 @@ pub fn run(
         .manage(AppState {
             current_file: Mutex::new(None),
             initial_files: Mutex::new(Vec::new()),
+            open_tabs: Mutex::new(Vec::new()),
             silent,
             json_output,
             stdin_mode,
@@ -228,6 +311,7 @@ pub fn run(
             file_ops::set_current_file,
             file_ops::get_current_file,
             file_ops::get_initial_files,
+            file_ops::submit_tab_states,
             file_ops::reveal_in_finder,
             file_ops::is_stdin_mode,
             file_ops::get_version,

--- a/file-review/src-tauri/src/lib.rs
+++ b/file-review/src-tauri/src/lib.rs
@@ -21,21 +21,30 @@ use tauri::{
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run(
-    file_path: Option<String>,
+    file_paths: Vec<String>,
     silent: bool,
     json_output: bool,
     stdin_mode: bool,
     original_content: Option<String>,
 ) {
+    let initial_files: Vec<std::path::PathBuf> =
+        file_paths.iter().map(std::path::PathBuf::from).collect();
+    let primary_file = initial_files.first().cloned();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .setup(move |app| {
-            // Store file path for frontend to retrieve
-            if let Some(ref path) = file_path {
+            // Seed AppState: current_file = first arg (single-file flows still
+            // work); initial_files = all args (JS opens a tab per path).
+            {
                 let state: tauri::State<'_, AppState> = app.state();
-                let mut current = state.current_file.lock().unwrap();
-                *current = Some(std::path::PathBuf::from(path));
+                if let Some(ref path) = primary_file {
+                    let mut current = state.current_file.lock().unwrap();
+                    *current = Some(path.clone());
+                }
+                let mut initial = state.initial_files.lock().unwrap();
+                *initial = initial_files.clone();
             }
 
             // Create menu with keyboard shortcuts
@@ -44,13 +53,30 @@ pub fn run(
                 .accelerator("CmdOrCtrl+S")
                 .build(app)?;
 
+            // Cmd+W closes the active tab (not the window). The OS-level
+            // accelerator emits `menu:close-tab` which JS handles. JS also
+            // registers a window-level keydown for the same key — whichever
+            // fires first calls `closeTab` and the other becomes a no-op.
+            let close_tab_item = MenuItemBuilder::new("Close Tab")
+                .id("close_tab")
+                .accelerator("CmdOrCtrl+W")
+                .build(app)?;
+
+            let new_tab_item = MenuItemBuilder::new("New Tab…")
+                .id("new_tab")
+                .accelerator("CmdOrCtrl+T")
+                .build(app)?;
+
             let quit_item = MenuItemBuilder::new("Quit")
                 .id("quit")
                 .accelerator("CmdOrCtrl+Q")
                 .build(app)?;
 
             let file_menu = SubmenuBuilder::new(app, "File")
+                .item(&new_tab_item)
+                .separator()
                 .item(&save_item)
+                .item(&close_tab_item)
                 .separator()
                 .item(&quit_item)
                 .build()?;
@@ -84,6 +110,16 @@ pub fn run(
                     "save" => {
                         if let Some(window) = app.get_webview_window("main") {
                             let _ = window.emit("menu:save", ());
+                        }
+                    }
+                    "close_tab" => {
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.emit("menu:close-tab", ());
+                        }
+                    }
+                    "new_tab" => {
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.emit("menu:new-tab", ());
                         }
                     }
                     "quit" => {
@@ -180,6 +216,7 @@ pub fn run(
         })
         .manage(AppState {
             current_file: Mutex::new(None),
+            initial_files: Mutex::new(Vec::new()),
             silent,
             json_output,
             stdin_mode,
@@ -190,6 +227,7 @@ pub fn run(
             file_ops::write_file,
             file_ops::set_current_file,
             file_ops::get_current_file,
+            file_ops::get_initial_files,
             file_ops::reveal_in_finder,
             file_ops::is_stdin_mode,
             file_ops::get_version,

--- a/file-review/src-tauri/src/main.rs
+++ b/file-review/src-tauri/src/main.rs
@@ -166,6 +166,7 @@ fn run_web_mode(
             initial_files: Mutex::new(
                 file_path.as_ref().map(|p| vec![PathBuf::from(p)]).unwrap_or_default(),
             ),
+            open_tabs: Mutex::new(Vec::new()),
             silent,
             json_output,
             stdin_mode,

--- a/file-review/src-tauri/src/main.rs
+++ b/file-review/src-tauri/src/main.rs
@@ -44,20 +44,30 @@ fn main() {
         .and_then(|w| w[1].parse().ok())
         .unwrap_or(3456);
 
-    // Extract file path (first non-flag argument after program name)
-    let file_arg = args
+    // Extract file paths (all non-flag arguments after program name).
+    // Excludes the value following --port and the port number itself.
+    let port_str = port.to_string();
+    let file_args: Vec<String> = args
         .iter()
         .skip(1)
-        .find(|a| !a.starts_with('-') && *a != &port.to_string())
-        .cloned();
+        .filter(|a| !a.starts_with('-') && *a != &port_str)
+        .cloned()
+        .map(resolve_cli_path)
+        .collect();
 
-    // Determine if stdin mode
-    let (file_path, stdin_mode, original_content) = match file_arg.as_deref() {
+    // Determine if stdin mode. Only the FIRST positional arg is checked for
+    // "-" / piped-stdin handling (matches existing behavior); remaining args
+    // are passed through as additional file paths.
+    let first = file_args.first().map(|s| s.as_str());
+    let (file_paths, stdin_mode, original_content): (Vec<String>, bool, Option<String>) = match first {
         Some("-") => {
-            // Explicit stdin mode with "-" argument
+            // Explicit stdin mode with "-" argument. Other paths after "-"
+            // are still appended.
             match read_stdin_to_temp() {
                 Ok((path, content)) => {
-                    (Some(path.to_string_lossy().to_string()), true, Some(content))
+                    let mut paths = vec![path.to_string_lossy().to_string()];
+                    paths.extend(file_args.iter().skip(1).cloned());
+                    (paths, true, Some(content))
                 }
                 Err(e) => {
                     eprintln!("Error reading stdin: {}", e);
@@ -69,7 +79,7 @@ fn main() {
             // Auto-detect piped stdin (no file arg and stdin is not a terminal)
             match read_stdin_to_temp() {
                 Ok((path, content)) => {
-                    (Some(path.to_string_lossy().to_string()), true, Some(content))
+                    (vec![path.to_string_lossy().to_string()], true, Some(content))
                 }
                 Err(e) => {
                     eprintln!("Error reading stdin: {}", e);
@@ -77,13 +87,14 @@ fn main() {
                 }
             }
         }
-        _ => (file_arg, false, None),
+        _ => (file_args, false, None),
     };
 
     // Web server mode
     #[cfg(feature = "web")]
     if web_mode {
-        run_web_mode(file_path, silent, json_output, stdin_mode, original_content, port, tunnel_enabled, auto_open, subdomain);
+        let primary = file_paths.first().cloned();
+        run_web_mode(primary, silent, json_output, stdin_mode, original_content, port, tunnel_enabled, auto_open, subdomain);
         return;
     }
 
@@ -94,7 +105,39 @@ fn main() {
     }
 
     // Tauri native mode
-    file_review_lib::run(file_path, silent, json_output, stdin_mode, original_content)
+    file_review_lib::run(file_paths, silent, json_output, stdin_mode, original_content)
+}
+
+/// Resolve a CLI file argument so relative paths work in `tauri dev`.
+///
+/// In production builds the binary's CWD is the user's shell CWD, so
+/// `./foo.md` works as-is. In `tauri dev`, cargo invokes the binary with
+/// CWD = `<project>/src-tauri/`, breaking the user's intuition of "open
+/// the file at this relative path from the directory I ran the command".
+///
+/// Strategy: keep absolute paths and `-` (stdin) as-is. For relative
+/// paths, canonicalize against CWD; if that fails, try CWD parent
+/// (handles dev-mode CWD = src-tauri/). Fall back to the original string
+/// if neither resolves so JS-side error reporting still surfaces.
+fn resolve_cli_path(arg: String) -> String {
+    if arg == "-" {
+        return arg;
+    }
+    let path = std::path::Path::new(&arg);
+    if path.is_absolute() {
+        return arg;
+    }
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return canonical.to_string_lossy().into_owned();
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Some(parent) = cwd.parent() {
+            if let Ok(canonical) = std::fs::canonicalize(parent.join(path)) {
+                return canonical.to_string_lossy().into_owned();
+            }
+        }
+    }
+    arg
 }
 
 #[cfg(feature = "web")]
@@ -116,9 +159,13 @@ fn run_web_mode(
     let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
 
     rt.block_on(async {
-        // Create app state
+        // Create app state. Web mode is single-file today (multi-file UX is
+        // Tauri-only for step-2); `initial_files` mirrors `current_file`.
         let app_state = Arc::new(AppState {
             current_file: Mutex::new(file_path.as_ref().map(PathBuf::from)),
+            initial_files: Mutex::new(
+                file_path.as_ref().map(|p| vec![PathBuf::from(p)]).unwrap_or_default(),
+            ),
             silent,
             json_output,
             stdin_mode,

--- a/file-review/src-tauri/src/web_server.rs
+++ b/file-review/src-tauri/src/web_server.rs
@@ -115,6 +115,7 @@ pub fn create_router(state: Arc<WebState>) -> Router {
         // API endpoints
         .route("/api/version", get(get_version))
         .route("/api/current-file", get(get_current_file))
+        .route("/api/initial-files", get(get_initial_files))
         .route("/api/read-file", post(read_file))
         .route("/api/write-file", post(write_file))
         .route("/api/set-current-file", post(set_current_file))
@@ -178,6 +179,18 @@ async fn get_current_file(Extension(state): Extension<Arc<WebState>>) -> impl In
     let current = state.app_state.current_file.lock().ok();
     let path = current.and_then(|f| f.as_ref().map(|p| p.to_string_lossy().to_string()));
     Json(path)
+}
+
+/// GET /api/initial-files
+async fn get_initial_files(Extension(state): Extension<Arc<WebState>>) -> impl IntoResponse {
+    let files: Vec<String> = state
+        .app_state
+        .initial_files
+        .lock()
+        .ok()
+        .map(|v| v.iter().map(|p| p.to_string_lossy().to_string()).collect())
+        .unwrap_or_default();
+    Json(files)
 }
 
 /// POST /api/read-file

--- a/file-review/src-tauri/tauri.conf.json
+++ b/file-review/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "file-review",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "identifier": "com.desplega.file-review",
   "build": {
     "beforeDevCommand": "bun run dev:vite",

--- a/file-review/src/api.ts
+++ b/file-review/src/api.ts
@@ -72,6 +72,7 @@ function commandToEndpoint(cmd: string): string {
   const mapping: Record<string, string> = {
     get_version: "/api/version",
     get_current_file: "/api/current-file",
+    get_initial_files: "/api/initial-files",
     read_file: "/api/read-file",
     write_file: "/api/write-file",
     set_current_file: "/api/set-current-file",
@@ -100,6 +101,7 @@ async function httpInvoke<T>(
   const getCommands = [
     "get_version",
     "get_current_file",
+    "get_initial_files",
     "is_stdin_mode",
     "load_config",
   ];
@@ -164,6 +166,10 @@ export const API = {
 
   async getCurrentFile(): Promise<string | null> {
     return this.invoke<string | null>("get_current_file");
+  },
+
+  async getInitialFiles(): Promise<string[]> {
+    return this.invoke<string[]>("get_initial_files");
   },
 
   async readFile(path: string): Promise<string> {

--- a/file-review/src/api.ts
+++ b/file-review/src/api.ts
@@ -172,6 +172,10 @@ export const API = {
     return this.invoke<string[]>("get_initial_files");
   },
 
+  async submitTabStates(states: Array<{ path: string; content: string }>): Promise<void> {
+    return this.invoke<void>("submit_tab_states", { states });
+  },
+
   async readFile(path: string): Promise<string> {
     return this.invoke<string>("read_file", { path });
   },

--- a/file-review/src/editor.ts
+++ b/file-review/src/editor.ts
@@ -150,3 +150,38 @@ export function onSelectionChange(callback: (hasSelection: boolean) => void) {
 export function onDocumentChange(callback: (changes: ChangeDesc) => void) {
   docChangeCallbacks.push(callback);
 }
+
+/**
+ * Snapshot the editor's per-tab state (cursor + scroll). Used in step-3 when
+ * activating a different tab — the outgoing tab's state is saved so we can
+ * restore it on next activation.
+ *
+ * The editor itself remains a single `EditorView` instance whose content is
+ * always "the active tab's content".
+ */
+export function getEditorState(): { cursor: { from: number; to: number }; scrollTop: number } {
+  const { from, to } = editorView.state.selection.main;
+  return {
+    cursor: { from, to },
+    scrollTop: editorView.scrollDOM.scrollTop,
+  };
+}
+
+/**
+ * Restore previously snapshotted editor state. Both `cursor` and `scrollTop`
+ * are optional so a freshly-loaded tab can hydrate just one side.
+ */
+export function setEditorState(state: {
+  cursor?: { from: number; to: number };
+  scrollTop?: number;
+}) {
+  if (state.cursor) {
+    const docLen = editorView.state.doc.length;
+    const from = Math.min(state.cursor.from, docLen);
+    const to = Math.min(state.cursor.to, docLen);
+    editorView.dispatch({ selection: { anchor: from, head: to } });
+  }
+  if (typeof state.scrollTop === "number") {
+    editorView.scrollDOM.scrollTop = state.scrollTop;
+  }
+}

--- a/file-review/src/file-picker.ts
+++ b/file-review/src/file-picker.ts
@@ -1,23 +1,31 @@
 import { isTauri } from "./api";
 
-export async function showFilePicker(): Promise<string | null> {
+/**
+ * Open the OS file picker, allowing multiple files. Returns an array of
+ * absolute paths (possibly empty) — never null. In web mode, returns [].
+ */
+export async function showFilePicker(): Promise<string[]> {
   // File picker is not available in web mode
   if (!isTauri()) {
-    return null;
+    return [];
   }
 
   // Dynamically import Tauri dialog plugin only when in Tauri mode
   const { open } = await import("@tauri-apps/plugin-dialog");
   const selected = await open({
-    multiple: false,
+    multiple: true,
     filters: [
       { name: "Markdown", extensions: ["md", "markdown"] },
       { name: "All Files", extensions: ["*"] },
     ],
   });
 
-  if (typeof selected === "string") {
+  if (Array.isArray(selected)) {
     return selected;
   }
-  return null;
+  // Fallback: shouldn't happen with multiple:true, but keep defensive.
+  if (typeof selected === "string") {
+    return [selected];
+  }
+  return [];
 }

--- a/file-review/src/main.ts
+++ b/file-review/src/main.ts
@@ -261,6 +261,15 @@ async function init() {
     toggleVim,
     toggleMarkdownView,
     openFile: showFilePickerAndLoad,
+    newTab: showFilePickerAndLoad,
+    closeTab: () => {
+      const active = tabManager.activeId;
+      if (active) closeTab(active);
+    },
+    jumpToTab: (n: number) => {
+      const target = tabManager.tabs[n - 1];
+      if (target) tabManager.setActive(target.id);
+    },
     zoomIn,
     zoomOut,
     undo: editorUndo,
@@ -272,22 +281,70 @@ async function init() {
   const versionBadge = document.getElementById("version-badge");
   if (versionBadge) versionBadge.textContent = `v${version}`;
 
-  // Get file path from Rust state (set from CLI args)
-  const filePath = await API.getCurrentFile();
+  // Wire active-tab swap: snapshot outgoing tab's editor doc, then load
+  // the incoming tab's content. `subscribeActiveChange` fires synchronously
+  // BEFORE the regular subscribe() listeners (tab-strip render).
+  tabManager.subscribeActiveChange((from, to) => {
+    if (from) snapshotActiveDocFor(from);
+    if (to) activateTab(to);
+    else clearActiveDisplay();
+  });
 
-  if (filePath) {
-    await loadFile(filePath);
-    hideEmptyState();
+  // Get file paths from Rust state (set from CLI args). Open one tab per
+  // path; the first becomes active. `getInitialFiles` returns [] if no
+  // args were passed.
+  const initialFiles = await API.getInitialFiles();
+  if (initialFiles.length > 0) {
+    let opened = 0;
+    for (const path of initialFiles) {
+      try {
+        await loadFile(path, "append");
+        opened++;
+      } catch (error) {
+        console.error("Failed to load CLI arg:", path, error);
+      }
+    }
+    if (opened > 0) {
+      hideEmptyState();
+    } else {
+      showEmptyState();
+    }
   } else {
     showEmptyState();
   }
 
-  // Listen for save command from menu (Tauri only)
+  // Listen for menu commands from Tauri menu (Tauri only).
   if (isTauri()) {
     const { listen } = await import("@tauri-apps/api/event");
     await listen("menu:save", async () => {
       await saveFile();
     });
+    await listen("menu:close-tab", () => {
+      const active = tabManager.activeId;
+      if (active) closeTab(active);
+    });
+    await listen("menu:new-tab", () => {
+      void showFilePickerAndLoad();
+    });
+
+    // Drag-drop: append every dropped file as a tab.
+    try {
+      const { getCurrentWebview } = await import("@tauri-apps/api/webview");
+      await getCurrentWebview().onDragDropEvent(async (event) => {
+        if (event.payload.type === "drop") {
+          for (const path of event.payload.paths) {
+            try {
+              await loadFile(path, "append");
+            } catch (error) {
+              console.error("Failed to load dropped file:", path, error);
+            }
+          }
+          if (tabManager.tabs.length > 0) hideEmptyState();
+        }
+      });
+    } catch (err) {
+      console.warn("Drag-drop not available:", err);
+    }
   }
 
   // Set up empty state open button
@@ -531,15 +588,19 @@ function hideEmptyState() {
 }
 
 async function showFilePickerAndLoad() {
-  if (!confirmDiscardUnsavedChanges("Open another file and discard them?")) {
-    return;
-  }
+  const paths = await showFilePicker();
+  if (paths.length === 0) return;
 
-  const filePath = await showFilePicker();
-  if (filePath) {
-    await loadFile(filePath);
-    hideEmptyState();
+  let opened = 0;
+  for (const path of paths) {
+    try {
+      await loadFile(path, "append");
+      opened++;
+    } catch (error) {
+      console.error("Failed to load picked file:", path, error);
+    }
   }
+  if (opened > 0) hideEmptyState();
 }
 
 async function toggleTheme() {
@@ -747,82 +808,137 @@ async function handleCommentSubmit(text: string, _lineNumber: number) {
   focusEditor();
 }
 
-async function loadFile(path: string) {
-  try {
-    const fileContent = await API.readFile(path);
-    const parsed = parseAndStripComments(fileContent);
-    await API.setCurrentFile(path);
+type LoadFileMode = "replace" | "append";
 
-    const isMarkdownFile = path.endsWith(".md") || path.endsWith(".markdown");
-    const initialRawMode = isMarkdownFile ? (appConfig.markdown_raw ?? false) : false;
-    const snapshot = serializeComments(parsed.cleanContent, parsed.comments);
-
-    // Step-1: replace-in-active-tab semantics. Step-2 will append a new tab.
-    if (tabManager.tabs.length === 0) {
-      tabManager.add({
-        path,
-        comments: parsed.comments,
-        isMarkdownFile,
-        isRawMode: initialRawMode,
-        hasUnsavedChanges: false,
-        lastSavedSnapshot: snapshot,
-        pendingPreviewComment: null,
-      });
-    } else {
-      const active = tabManager.getActive();
-      if (active) {
-        tabManager.update(active.id, {
-          path,
-          comments: parsed.comments,
-          isMarkdownFile,
-          isRawMode: initialRawMode,
-          hasUnsavedChanges: false,
-          lastSavedSnapshot: snapshot,
-          pendingPreviewComment: null,
-        });
-      }
-    }
-
-    withSuppressedCommentSync(() => {
-      setEditorContent(parsed.cleanContent);
-    });
-
-    // Check if stdin mode for UI adjustments
-    const isStdin = await API.isStdinMode();
-    updateFileNameDisplay(path, isStdin);
-
-    const toggleBtn = document.getElementById("markdown-toggle");
-    if (toggleBtn) {
-      toggleBtn.style.display = isMarkdownFile ? "flex" : "none";
-    }
-
-    // Show comment button
-    const commentBtn = document.getElementById("add-comment-btn");
-    if (commentBtn) commentBtn.style.display = "flex";
-
-    // Render existing comments/highlights from in-memory state
-    renderCommentState();
-
-    // Set up view mode for markdown files
-    if (isMarkdownFile) {
-      updateViewMode();
-    } else {
-      // For non-markdown files, ensure editor is visible and hide ToC
-      const editorContainer = document.getElementById("editor-container")!;
-      const previewWrapper = document.getElementById("preview-wrapper")!;
-      const tocPanel = document.getElementById("sidebar-toc-panel");
-      editorContainer.style.display = "block";
-      previewWrapper.style.display = "none";
-      if (tocPanel) tocPanel.style.display = "none";
-    }
-
-    // Focus editor (only if in raw mode or not a markdown file)
-    if (initialRawMode || !isMarkdownFile) {
-      focusEditor();
-    }
-  } catch (error) {
-    console.error("Failed to load file:", error);
+/**
+ * Open `path` as a tab.
+ *
+ * - `append` (default): if a tab already has this path, switch to it; else
+ *   create a new tab and make it active. Used by CLI args, drag-drop,
+ *   `Cmd+T`, the toolbar Open button, and the empty-state Open button.
+ * - `replace`: load into the active tab (creating one if none exists).
+ *   Reserved for future "reopen in current tab" affordances.
+ *
+ * Throws on file-read failure so callers can decide whether to surface
+ * (e.g. CLI args at startup → bail to empty state on full failure).
+ */
+async function loadFile(path: string, mode: LoadFileMode = "append"): Promise<void> {
+  // De-dupe: if the file is already open, just activate its tab.
+  const existing = tabManager.findByPath(path);
+  if (existing && mode === "append") {
+    tabManager.setActive(existing.id);
+    return;
   }
+
+  const fileContent = await API.readFile(path);
+  const parsed = parseAndStripComments(fileContent);
+  await API.setCurrentFile(path);
+
+  const isMarkdownFile = path.endsWith(".md") || path.endsWith(".markdown");
+  const initialRawMode = isMarkdownFile ? (appConfig.markdown_raw ?? false) : false;
+  const snapshot = serializeComments(parsed.cleanContent, parsed.comments);
+  const tabFields = {
+    path,
+    doc: parsed.cleanContent,
+    comments: parsed.comments,
+    isMarkdownFile,
+    isRawMode: initialRawMode,
+    hasUnsavedChanges: false,
+    lastSavedSnapshot: snapshot,
+    pendingPreviewComment: null,
+  };
+
+  if (mode === "replace") {
+    const active = tabManager.getActive();
+    if (active) {
+      tabManager.update(active.id, tabFields);
+    } else {
+      tabManager.add(tabFields);
+    }
+  } else {
+    // append: always create a new tab (we already de-duped above).
+    tabManager.add(tabFields);
+  }
+
+  // The activeChange subscriber handles editor + preview hydration. For
+  // the very first tab where `from` was null and we're already on `to`,
+  // we still need to render — call activateTab explicitly to be safe.
+  const active = tabManager.getActive();
+  if (active && active.path === path) {
+    activateTabUI(active);
+  }
+}
+
+/**
+ * Hydrate the singleton editor/preview/sidebar/toolbar from a tab's
+ * in-memory state. Called by the active-change subscriber.
+ */
+function activateTabUI(tab: Tab) {
+  withSuppressedCommentSync(() => {
+    setEditorContent(tab.doc);
+  });
+
+  // Show toolbar/file-name UI
+  void (async () => {
+    const isStdin = tab.path ? await API.isStdinMode() : false;
+    if (tab.path) updateFileNameDisplay(tab.path, isStdin);
+  })();
+
+  const toggleBtn = document.getElementById("markdown-toggle");
+  if (toggleBtn) {
+    toggleBtn.style.display = tab.isMarkdownFile ? "flex" : "none";
+  }
+  const commentBtn = document.getElementById("add-comment-btn");
+  if (commentBtn) commentBtn.style.display = "flex";
+
+  renderCommentState();
+
+  if (tab.isMarkdownFile) {
+    updateViewMode();
+  } else {
+    const editorContainer = document.getElementById("editor-container")!;
+    const previewWrapper = document.getElementById("preview-wrapper")!;
+    const tocPanel = document.getElementById("sidebar-toc-panel");
+    editorContainer.style.display = "block";
+    previewWrapper.style.display = "none";
+    if (tocPanel) tocPanel.style.display = "none";
+  }
+
+  if (tab.isRawMode || !tab.isMarkdownFile) {
+    focusEditor();
+  }
+}
+
+/**
+ * Snapshot the outgoing tab's editor doc into TabManager state before a
+ * tab swap. Cursor/scroll preservation is step-3.
+ */
+function snapshotActiveDocFor(tabId: string) {
+  const tab = tabManager.tabs.find((t) => t.id === tabId);
+  if (!tab) return;
+  tabManager.update(tab.id, { doc: getEditorContent() });
+}
+
+/** Lookup the tab by id and hydrate the UI from it. */
+function activateTab(tabId: string) {
+  const tab = tabManager.tabs.find((t) => t.id === tabId);
+  if (!tab) return;
+  void API.setCurrentFile(tab.path ?? "");
+  activateTabUI(tab);
+}
+
+/** Reset UI to empty-state visuals (no tab open). */
+function clearActiveDisplay() {
+  withSuppressedCommentSync(() => setEditorContent(""));
+  const toggleBtn = document.getElementById("markdown-toggle");
+  if (toggleBtn) toggleBtn.style.display = "none";
+  const commentBtn = document.getElementById("add-comment-btn");
+  if (commentBtn) commentBtn.style.display = "none";
+  const fileNameEl = document.getElementById("file-name");
+  if (fileNameEl) fileNameEl.style.display = "none";
+  const openBtn = document.getElementById("open-file-btn");
+  if (openBtn) openBtn.style.display = "flex";
+  showEmptyState();
 }
 
 function updateFileNameDisplay(path: string, isStdin = false) {

--- a/file-review/src/main.ts
+++ b/file-review/src/main.ts
@@ -4,6 +4,8 @@ import {
   getEditorContent,
   setEditorContent,
   getEditorView,
+  getEditorState,
+  setEditorState,
   getSelection,
   scrollToPosition,
   updateTheme,
@@ -290,6 +292,10 @@ async function init() {
     else clearActiveDisplay();
   });
 
+  // Keep Rust's `open_tabs` in sync with JS state. Debounced so we don't
+  // spam Tauri IPC on every comment-remap-through-keystroke.
+  tabManager.subscribe(schedulePushTabStates);
+
   // Get file paths from Rust state (set from CLI args). Open one tab per
   // path; the first becomes active. `getInitialFiles` returns [] if no
   // args were passed.
@@ -393,6 +399,12 @@ async function init() {
   });
 
   window.addEventListener("beforeunload", (event) => {
+    // Fire-and-forget — push every tab's in-memory state to Rust so the
+    // close-window handler dumps comments from ALL files, not just the
+    // active one. Tauri's CloseRequested fires after `beforeunload`
+    // returns, giving this just enough time to land.
+    void pushTabStatesToRust();
+
     if (!readActive()?.hasUnsavedChanges) {
       return;
     }
@@ -878,6 +890,10 @@ function activateTabUI(tab: Tab) {
     setEditorContent(tab.doc);
   });
 
+  // Restore cursor + scroll from the tab's snapshot (no-ops on first
+  // activation when both are unset).
+  setEditorState({ cursor: tab.cursor, scrollTop: tab.scrollTop });
+
   // Show toolbar/file-name UI
   void (async () => {
     const isStdin = tab.path ? await API.isStdinMode() : false;
@@ -910,13 +926,19 @@ function activateTabUI(tab: Tab) {
 }
 
 /**
- * Snapshot the outgoing tab's editor doc into TabManager state before a
- * tab swap. Cursor/scroll preservation is step-3.
+ * Snapshot the outgoing tab's editor doc + cursor + scroll into the
+ * TabManager state before a tab swap. Caller invokes this from the
+ * `subscribeActiveChange` hook with the outgoing tab's id.
  */
 function snapshotActiveDocFor(tabId: string) {
   const tab = tabManager.tabs.find((t) => t.id === tabId);
   if (!tab) return;
-  tabManager.update(tab.id, { doc: getEditorContent() });
+  const editorState = getEditorState();
+  tabManager.update(tab.id, {
+    doc: getEditorContent(),
+    cursor: editorState.cursor,
+    scrollTop: editorState.scrollTop,
+  });
 }
 
 /** Lookup the tab by id and hydrate the UI from it. */
@@ -925,6 +947,51 @@ function activateTab(tabId: string) {
   if (!tab) return;
   void API.setCurrentFile(tab.path ?? "");
   activateTabUI(tab);
+}
+
+/**
+ * Debounced trigger for `pushTabStatesToRust`. Hooked into every
+ * `tabManager` mutation so `open_tabs` in Rust is always fresh by the
+ * time the user closes the window. Without this, the Rust
+ * `CloseRequested` handler would fire before the async push from
+ * `beforeunload` completes and would fall back to a single-file disk
+ * read, missing comments from inactive tabs.
+ */
+let pushTabStatesTimer: number | null = null;
+function schedulePushTabStates() {
+  if (pushTabStatesTimer !== null) {
+    clearTimeout(pushTabStatesTimer);
+  }
+  pushTabStatesTimer = window.setTimeout(() => {
+    pushTabStatesTimer = null;
+    void pushTabStatesToRust();
+  }, 150);
+}
+
+/**
+ * Push every open tab's in-memory state to Rust so the close-window
+ * comment-export flow has fresh content for ALL tabs, not just the active
+ * one. Snapshots the active tab first so its uncommitted edits land too.
+ *
+ * Called from a debounced subscriber on every `tabManager` mutation, plus
+ * synchronously on tab-close and `beforeunload` for closing-window safety.
+ */
+async function pushTabStatesToRust(): Promise<void> {
+  const active = tabManager.getActive();
+  if (active) {
+    tabManager.update(active.id, { doc: getEditorContent() });
+  }
+  const states = tabManager.tabs
+    .filter((t) => t.path !== null)
+    .map((t) => ({
+      path: t.path!,
+      content: serializeComments(t.doc, t.comments),
+    }));
+  try {
+    await API.submitTabStates(states);
+  } catch (error) {
+    console.error("Failed to push tab states:", error);
+  }
 }
 
 /** Reset UI to empty-state visuals (no tab open). */
@@ -1038,6 +1105,7 @@ function closeTab(id: string) {
     }
   }
   tabManager.remove(id);
+  void pushTabStatesToRust();
 
   const remaining = tabManager.getActive();
   if (!remaining) {

--- a/file-review/src/main.ts
+++ b/file-review/src/main.ts
@@ -49,27 +49,36 @@ import {
   flashElement,
   getPreviewContainer,
 } from "./markdown-preview";
-import { extractTocEntries, renderToc } from "./toc";
+import { extractTocEntries, initToc, renderToc } from "./toc";
 import { PreviewNavigator } from "./preview-nav";
+import { TabManager, type Tab } from "./tabs";
+import { initTabStrip } from "./tabs-view";
 
-let currentFilePath: string | null = null;
-let comments: ReviewComment[] = [];
+const tabManager = new TabManager();
+
+// Global UI state — NOT per-tab. Vim mode and theme are app-wide settings.
 let currentTheme: Theme = "dark";
 let vimEnabled = false;
 let appConfig: AppConfig;
-let isMarkdownFile = false;
-let isRawMode = false; // false = pretty/rendered, true = raw CodeMirror
 let suppressCommentSync = false;
-let hasUnsavedChanges = false;
-let lastSavedSnapshot = "";
 let previewNav: PreviewNavigator | null = null;
 
-// For preview mode commenting
-let pendingPreviewComment: {
-  sourceStart: number;
-  sourceEnd: number;
-  element: HTMLElement;
-} | null = null;
+/**
+ * Read fields from the active tab. Returns null if no tab is open — callers
+ * that touch tab state must guard.
+ */
+function readActive(): Tab | null {
+  return tabManager.getActive();
+}
+
+/**
+ * Patch fields on the active tab. No-op if no tab is open.
+ */
+function writeActive(patch: Partial<Tab>): void {
+  const active = tabManager.getActive();
+  if (!active) return;
+  tabManager.update(active.id, patch);
+}
 
 // Toast notifications
 export function showToast(message: string, type: "success" | "info" = "info") {
@@ -106,31 +115,38 @@ function withSuppressedCommentSync<T>(fn: () => T): T {
 }
 
 function getSerializedContentForPersistence(content = getEditorContent()): string {
-  return serializeComments(content, comments);
+  const active = readActive();
+  return serializeComments(content, active?.comments ?? []);
 }
 
 function markSnapshotAsSaved(snapshot: string) {
-  lastSavedSnapshot = snapshot;
-  hasUnsavedChanges = false;
+  writeActive({ lastSavedSnapshot: snapshot, hasUnsavedChanges: false });
 }
 
 function syncUnsavedChangesState() {
-  if (!currentFilePath) {
-    hasUnsavedChanges = false;
+  const active = readActive();
+  if (!active || !active.path) {
+    if (active) writeActive({ hasUnsavedChanges: false });
     return;
   }
-  hasUnsavedChanges = getSerializedContentForPersistence() !== lastSavedSnapshot;
+  const dirty =
+    serializeComments(getEditorContent(), active.comments) !== active.lastSavedSnapshot;
+  if (dirty !== active.hasUnsavedChanges) {
+    writeActive({ hasUnsavedChanges: dirty });
+  }
 }
 
 function confirmDiscardUnsavedChanges(action: string): boolean {
-  if (!hasUnsavedChanges) {
+  const active = readActive();
+  if (!active?.hasUnsavedChanges) {
     return true;
   }
   return window.confirm(`You have unsaved changes. ${action}`);
 }
 
 function handleTocClick(entry: import('./toc').TocEntry) {
-  if (isRawMode) {
+  const active = readActive();
+  if (active?.isRawMode) {
     const view = getEditorView();
     view.dispatch({ selection: { anchor: entry.sourcePos } });
     scrollToPosition(entry.sourcePos);
@@ -146,14 +162,17 @@ function handleTocClick(entry: import('./toc').TocEntry) {
 }
 
 function renderCommentState() {
+  const active = readActive();
+  const comments = active?.comments ?? [];
+
   renderComments(comments);
 
   const content = getEditorContent();
-  if (isMarkdownFile && !isRawMode) {
+  if (active?.isMarkdownFile && !active.isRawMode) {
     updatePreview(content, comments);
     previewNav?.reset();
   }
-  if (isMarkdownFile) {
+  if (active?.isMarkdownFile) {
     const entries = extractTocEntries(content);
     renderToc(entries, handleTocClick);
   }
@@ -197,16 +216,33 @@ async function init() {
   updateVimButton();
 
   // Initialize sidebar handlers
-  initSidebar(handleDeleteComment, handleCommentClick, handleCommentSubmit, handleEditComment);
+  initSidebar(
+    handleDeleteComment,
+    handleCommentClick,
+    handleCommentSubmit,
+    handleEditComment,
+    readActive
+  );
   setupCommentInput();
 
   // Initialize markdown preview
-  initPreview(document.getElementById("preview-container")!);
+  initPreview(document.getElementById("preview-container")!, readActive);
+
+  // Initialize ToC (passes active-tab accessor for step-2/3 forward-compat)
+  initToc(readActive);
+
+  // Initialize tab strip
+  initTabStrip(tabManager, {
+    onActivate: (id) => tabManager.setActive(id),
+    onClose: (id) => closeTab(id),
+  });
 
   // Initialize preview navigator (vim nav + search)
   previewNav = new PreviewNavigator(
     () => getPreviewContainer(),
-    () => vimEnabled
+    () => vimEnabled,
+    undefined,
+    readActive
   );
 
   // Set up interactive preview commenting
@@ -283,19 +319,21 @@ async function init() {
       return;
     }
 
-    if (comments.length === 0) {
+    const active = readActive();
+    if (!active || active.comments.length === 0) {
       syncUnsavedChangesState();
       return;
     }
 
-    comments = mapCommentsThroughChanges(comments, (pos, assoc) =>
+    const remapped = mapCommentsThroughChanges(active.comments, (pos, assoc) =>
       changes.mapPos(pos, assoc)
     );
+    writeActive({ comments: remapped });
     renderCommentState();
   });
 
   window.addEventListener("beforeunload", (event) => {
-    if (!hasUnsavedChanges) {
+    if (!readActive()?.hasUnsavedChanges) {
       return;
     }
     event.preventDefault();
@@ -304,7 +342,8 @@ async function init() {
 
   // Listen for preview comment clicks (when clicking on highlighted text)
   window.addEventListener("preview-comment-click", ((e: CustomEvent<{ commentId: string }>) => {
-    const comment = comments.find(c => c.id === e.detail.commentId);
+    const active = readActive();
+    const comment = active?.comments.find(c => c.id === e.detail.commentId);
     if (comment) {
       // Highlight the comment card in sidebar
       const card = document.querySelector(`[data-comment-id="${comment.id}"]`);
@@ -318,7 +357,8 @@ async function init() {
 
   // Listen for preview element clicks (when clicking on commentable element with a comment)
   window.addEventListener("preview-element-click", ((e: CustomEvent<{ commentId: string; element: HTMLElement }>) => {
-    const comment = comments.find(c => c.id === e.detail.commentId);
+    const active = readActive();
+    const comment = active?.comments.find(c => c.id === e.detail.commentId);
     if (comment) {
       // Scroll and highlight the comment card in sidebar
       const card = document.querySelector(`[data-comment-id="${comment.id}"]`);
@@ -544,22 +584,28 @@ async function zoomOut() {
 }
 
 async function toggleMarkdownView() {
-  if (!isMarkdownFile) return;
+  const active = readActive();
+  if (!active?.isMarkdownFile) return;
 
-  isRawMode = !isRawMode;
-  appConfig.markdown_raw = isRawMode;
+  const newRawMode = !active.isRawMode;
+  writeActive({ isRawMode: newRawMode });
+  appConfig.markdown_raw = newRawMode;
   await saveConfig(appConfig);
 
   updateViewMode();
 }
 
 function updateViewMode() {
+  const active = readActive();
   const editorContainer = document.getElementById("editor-container")!;
   const previewWrapper = document.getElementById("preview-wrapper")!;
   const toggleBtn = document.getElementById("markdown-toggle");
   const tocPanel = document.getElementById("sidebar-toc-panel");
 
-  if (isRawMode) {
+  const isMarkdown = active?.isMarkdownFile ?? false;
+  const isRaw = active?.isRawMode ?? false;
+
+  if (isRaw) {
     editorContainer.style.display = "block";
     previewWrapper.style.display = "none";
     toggleBtn?.classList.remove("active");
@@ -567,21 +613,22 @@ function updateViewMode() {
     editorContainer.style.display = "none";
     previewWrapper.style.display = "flex";
     toggleBtn?.classList.add("active");
-    updatePreview(getEditorContent(), comments);
+    updatePreview(getEditorContent(), active?.comments ?? []);
     previewNav?.reset();
   }
 
   // ToC is always visible for markdown files regardless of mode
-  if (tocPanel) tocPanel.style.display = isMarkdownFile ? "flex" : "none";
-  if (isMarkdownFile) {
+  if (tocPanel) tocPanel.style.display = isMarkdown ? "flex" : "none";
+  if (isMarkdown) {
     const entries = extractTocEntries(getEditorContent());
     renderToc(entries, handleTocClick);
   }
 }
 
 function handleAddCommentShortcut() {
+  const active = readActive();
   // In preview mode, use the active block from preview navigation
-  if (!isRawMode && isMarkdownFile) {
+  if (active && !active.isRawMode && active.isMarkdownFile) {
     const previewContainer = getPreviewContainer();
     const activeEl = previewContainer?.querySelector<HTMLElement>('.preview-active');
     if (activeEl) {
@@ -621,8 +668,8 @@ function handlePreviewAddComment(
   sourceEnd: number,
   element: HTMLElement
 ) {
-  // Store pending preview comment info
-  pendingPreviewComment = { sourceStart, sourceEnd, element };
+  // Store pending preview comment info on the active tab
+  writeActive({ pendingPreviewComment: { sourceStart, sourceEnd, element } });
 
   // Show comment input in sidebar with element type label
   const tagName = element.tagName.toLowerCase();
@@ -638,12 +685,20 @@ function handlePreviewAddComment(
 }
 
 async function handleCommentSubmit(text: string, _lineNumber: number) {
-  // Handle preview mode comment
-  if (pendingPreviewComment) {
-    const { sourceStart, sourceEnd, element } = pendingPreviewComment;
-    pendingPreviewComment = null;
+  const active = readActive();
+  if (!active) {
+    hideCommentInput();
+    return;
+  }
 
-    comments = addComment(comments, createComment("line", sourceStart, sourceEnd, text));
+  // Handle preview mode comment
+  if (active.pendingPreviewComment) {
+    const { sourceStart, sourceEnd, element } = active.pendingPreviewComment;
+    const next = addComment(
+      active.comments,
+      createComment("line", sourceStart, sourceEnd, text)
+    );
+    writeActive({ comments: next, pendingPreviewComment: null });
     renderCommentState();
 
     // Flash the element for visual feedback
@@ -669,18 +724,20 @@ async function handleCommentSubmit(text: string, _lineNumber: number) {
   const isFullLineSelection =
     selection.from === startLine.from && selection.to === startLine.to;
 
+  let next: ReviewComment[];
   if (isMultiLine || isFullLineSelection) {
     // For multi-line or full-line selections, use line-based comments.
     const lineStart = startLine.from;
     const lineEnd = endLine.to;
-    comments = addComment(comments, createComment("line", lineStart, lineEnd, text));
+    next = addComment(active.comments, createComment("line", lineStart, lineEnd, text));
   } else {
-    comments = addComment(
-      comments,
+    next = addComment(
+      active.comments,
       createComment("inline", selection.from, selection.to, text)
     );
   }
 
+  writeActive({ comments: next });
   renderCommentState();
   showToast("Comment added", "success");
   focusEditor();
@@ -690,10 +747,37 @@ async function loadFile(path: string) {
   try {
     const fileContent = await API.readFile(path);
     const parsed = parseAndStripComments(fileContent);
-    currentFilePath = path;
     await API.setCurrentFile(path);
-    comments = parsed.comments;
-    markSnapshotAsSaved(serializeComments(parsed.cleanContent, parsed.comments));
+
+    const isMarkdownFile = path.endsWith(".md") || path.endsWith(".markdown");
+    const initialRawMode = isMarkdownFile ? (appConfig.markdown_raw ?? false) : false;
+    const snapshot = serializeComments(parsed.cleanContent, parsed.comments);
+
+    // Step-1: replace-in-active-tab semantics. Step-2 will append a new tab.
+    if (tabManager.tabs.length === 0) {
+      tabManager.add({
+        path,
+        comments: parsed.comments,
+        isMarkdownFile,
+        isRawMode: initialRawMode,
+        hasUnsavedChanges: false,
+        lastSavedSnapshot: snapshot,
+        pendingPreviewComment: null,
+      });
+    } else {
+      const active = tabManager.getActive();
+      if (active) {
+        tabManager.update(active.id, {
+          path,
+          comments: parsed.comments,
+          isMarkdownFile,
+          isRawMode: initialRawMode,
+          hasUnsavedChanges: false,
+          lastSavedSnapshot: snapshot,
+          pendingPreviewComment: null,
+        });
+      }
+    }
 
     withSuppressedCommentSync(() => {
       setEditorContent(parsed.cleanContent);
@@ -703,8 +787,6 @@ async function loadFile(path: string) {
     const isStdin = await API.isStdinMode();
     updateFileNameDisplay(path, isStdin);
 
-    // Check if this is a markdown file
-    isMarkdownFile = path.endsWith(".md") || path.endsWith(".markdown");
     const toggleBtn = document.getElementById("markdown-toggle");
     if (toggleBtn) {
       toggleBtn.style.display = isMarkdownFile ? "flex" : "none";
@@ -719,7 +801,6 @@ async function loadFile(path: string) {
 
     // Set up view mode for markdown files
     if (isMarkdownFile) {
-      isRawMode = appConfig.markdown_raw ?? false;
       updateViewMode();
     } else {
       // For non-markdown files, ensure editor is visible and hide ToC
@@ -732,7 +813,7 @@ async function loadFile(path: string) {
     }
 
     // Focus editor (only if in raw mode or not a markdown file)
-    if (isRawMode || !isMarkdownFile) {
+    if (initialRawMode || !isMarkdownFile) {
       focusEditor();
     }
   } catch (error) {
@@ -782,11 +863,12 @@ async function revealInFinder(path: string) {
 }
 
 async function saveFile() {
-  if (!currentFilePath) return;
+  const active = readActive();
+  if (!active?.path) return;
 
   try {
     const contentWithComments = getSerializedContentForPersistence();
-    await API.writeFile(currentFilePath, contentWithComments);
+    await API.writeFile(active.path, contentWithComments);
     markSnapshotAsSaved(contentWithComments);
     showToast("File saved", "success");
   } catch (error) {
@@ -795,24 +877,67 @@ async function saveFile() {
 }
 
 function handleDeleteComment(commentId: string) {
-  comments = comments.filter((comment) => comment.id !== commentId);
+  const active = readActive();
+  if (!active) return;
+  writeActive({ comments: active.comments.filter((c) => c.id !== commentId) });
   renderCommentState();
   showToast("Comment removed", "info");
 }
 
 function handleEditComment(commentId: string, newText: string) {
-  const comment = comments.find((c) => c.id === commentId);
-  if (!comment) return;
-  comment.text = newText;
+  const active = readActive();
+  if (!active) return;
+  // Mutate the comment in place, then re-set the array so subscribers fire.
+  const next = active.comments.map((c) =>
+    c.id === commentId ? { ...c, text: newText } : c
+  );
+  writeActive({ comments: next });
   renderCommentState();
   showToast("Comment updated", "success");
 }
 
 function handleCommentClick(comment: ReviewComment) {
-  if (isMarkdownFile && !isRawMode) {
+  const active = readActive();
+  if (active?.isMarkdownFile && !active.isRawMode) {
     scrollPreviewToComment(comment.id);
   } else {
     scrollToPosition(comment.highlight_start);
+  }
+}
+
+/**
+ * Close a tab by id. In step-1 only the active tab can be closed (single-tab
+ * semantics); step-2 will allow closing any tab.
+ */
+function closeTab(id: string) {
+  const tab = tabManager.tabs.find((t) => t.id === id);
+  if (!tab) return;
+  if (tab.hasUnsavedChanges) {
+    if (!window.confirm("You have unsaved changes. Close this tab and discard them?")) {
+      return;
+    }
+  }
+  tabManager.remove(id);
+
+  const remaining = tabManager.getActive();
+  if (!remaining) {
+    // No tabs left — return to empty state
+    withSuppressedCommentSync(() => {
+      setEditorContent("");
+    });
+    showEmptyState();
+    // Hide file-bound UI elements that loadFile() showed
+    const fileNameEl = document.getElementById("file-name");
+    if (fileNameEl) fileNameEl.style.display = "none";
+    const openBtn = document.getElementById("open-file-btn");
+    if (openBtn) openBtn.style.display = "";
+    const commentBtn = document.getElementById("add-comment-btn");
+    if (commentBtn) commentBtn.style.display = "none";
+    const toggleBtn = document.getElementById("markdown-toggle");
+    if (toggleBtn) toggleBtn.style.display = "none";
+    const tocPanel = document.getElementById("sidebar-toc-panel");
+    if (tocPanel) tocPanel.style.display = "none";
+    renderComments([]);
   }
 }
 

--- a/file-review/src/main.ts
+++ b/file-review/src/main.ts
@@ -48,7 +48,9 @@ import {
   initInteractiveCommenting,
   flashElement,
   getPreviewContainer,
+  refreshMermaidForTheme,
 } from "./markdown-preview";
+import { initMermaid } from "./mermaid";
 import { extractTocEntries, initToc, renderToc } from "./toc";
 import { PreviewNavigator } from "./preview-nav";
 import { TabManager, type Tab } from "./tabs";
@@ -227,6 +229,7 @@ async function init() {
 
   // Initialize markdown preview
   initPreview(document.getElementById("preview-container")!, readActive);
+  initMermaid(() => currentTheme);
 
   // Initialize ToC (passes active-tab accessor for step-2/3 forward-compat)
   initToc(readActive);
@@ -546,6 +549,7 @@ async function toggleTheme() {
   document.body.classList.toggle("light-theme", currentTheme === "light");
   updateTheme(currentTheme);
   updateThemeButton();
+  refreshMermaidForTheme();
 }
 
 function updateThemeButton() {

--- a/file-review/src/markdown-preview.ts
+++ b/file-review/src/markdown-preview.ts
@@ -12,6 +12,7 @@ import rust from 'highlight.js/lib/languages/rust';
 import sql from 'highlight.js/lib/languages/sql';
 import markdown from 'highlight.js/lib/languages/markdown';
 import type { ReviewComment } from './comments';
+import type { Tab } from './tabs';
 
 // Register languages with aliases
 hljs.registerLanguage('javascript', javascript);
@@ -42,6 +43,10 @@ let currentHoverElement: HTMLElement | null = null;
 let addCommentCallback: ((sourceStart: number, sourceEnd: number, element: HTMLElement) => void) | null = null;
 let hoverListenersAttached = false;
 let hideTimeout: ReturnType<typeof setTimeout> | null = null;
+// Reserved for step-2/3: lets the preview module read active-tab state
+// (path, comments, etc.) without re-threading them through every call. Passed
+// in once at startup via `initPreview`.
+let getActiveTab: () => Tab | null = () => null;
 
 const COMMENTABLE_SELECTORS = 'p, h1, h2, h3, h4, h5, h6, li, blockquote, pre, tr';
 const COMMENTABLE_HEADING_KINDS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
@@ -92,8 +97,17 @@ export function slugify(text: string): string {
     .replace(/\s+/g, '-');
 }
 
-export function initPreview(container: HTMLElement) {
+export function initPreview(
+  container: HTMLElement,
+  activeTabAccessor: () => Tab | null = () => null
+) {
   previewContainer = container;
+  getActiveTab = activeTabAccessor;
+}
+
+// Forward-compat hook for step-2/3.
+export function getActiveTabFromPreview(): Tab | null {
+  return getActiveTab();
 }
 
 /**

--- a/file-review/src/markdown-preview.ts
+++ b/file-review/src/markdown-preview.ts
@@ -1011,6 +1011,43 @@ function highlightCodeBlocks() {
   });
 }
 
+function addCopyButtons() {
+  if (!previewContainer) return;
+  const pres = previewContainer.querySelectorAll<HTMLPreElement>('pre');
+  pres.forEach((pre) => {
+    if (pre.classList.contains('mermaid')) return;
+    if (pre.querySelector(':scope > .code-copy-btn')) return;
+    const code = pre.querySelector('code');
+    if (!code) return;
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'code-copy-btn';
+    btn.textContent = 'Copy';
+    btn.setAttribute('aria-label', 'Copy code to clipboard');
+    btn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      try {
+        await navigator.clipboard.writeText(code.innerText);
+        btn.textContent = 'Copied';
+        btn.classList.add('copied');
+        setTimeout(() => {
+          btn.textContent = 'Copy';
+          btn.classList.remove('copied');
+        }, 1200);
+      } catch {
+        btn.textContent = 'Failed';
+        setTimeout(() => { btn.textContent = 'Copy'; }, 1200);
+      }
+    });
+
+    if (getComputedStyle(pre).position === 'static') {
+      pre.style.position = 'relative';
+    }
+    pre.appendChild(btn);
+  });
+}
+
 // Cancel any in-flight mermaid render whenever a fresh `updatePreview` runs —
 // only the latest call's diagrams should land in the DOM.
 let activeMermaidController: AbortController | null = null;
@@ -1036,6 +1073,7 @@ export function updatePreview(content: string, comments: ReviewComment[]) {
   // hljs runs after — walkTokens already converted ```mermaid fences to html
   // tokens, so there are no `language-mermaid` blocks for hljs to mangle.
   highlightCodeBlocks();
+  addCopyButtons();
 }
 
 export function scrollPreviewToComment(commentId: string) {

--- a/file-review/src/markdown-preview.ts
+++ b/file-review/src/markdown-preview.ts
@@ -13,6 +13,7 @@ import sql from 'highlight.js/lib/languages/sql';
 import markdown from 'highlight.js/lib/languages/markdown';
 import type { ReviewComment } from './comments';
 import type { Tab } from './tabs';
+import { renderMermaidBlocks, resetMermaidProcessed } from './mermaid';
 
 // Register languages with aliases
 hljs.registerLanguage('javascript', javascript);
@@ -36,6 +37,34 @@ hljs.registerAliases(['html', 'htm', 'svg'], { languageName: 'xml' });
 hljs.registerAliases(['yml'], { languageName: 'yaml' });
 hljs.registerAliases(['md'], { languageName: 'markdown' });
 hljs.registerAliases(['rs'], { languageName: 'rust' });
+
+// Mermaid integration: rewrite ` ```mermaid ` code tokens into `html` tokens
+// at parse time so marked's default code renderer (and downstream hljs) never
+// sees them. The original source is stashed in `data-src` (URI-encoded) so
+// theme switches can restore + re-render the diagrams.
+//
+// MUST be registered exactly once at module scope. `marked.use()` inside a
+// render call recurses and corrupts state.
+marked.use({
+  walkTokens(token) {
+    if (token.type === 'code' && (token as Tokens.Code).lang === 'mermaid') {
+      const codeToken = token as Tokens.Code;
+      const source = codeToken.text ?? '';
+      // Mutating the in-place token: change `type` to 'html' and set `text` to
+      // the desired HTML. marked treats `html` tokens as raw passthrough.
+      const mutable = codeToken as unknown as {
+        type: string;
+        pre: boolean;
+        text: string;
+        block?: boolean;
+      };
+      mutable.type = 'html';
+      mutable.pre = false;
+      mutable.block = true;
+      mutable.text = `<pre class="mermaid" data-src="${encodeURIComponent(source)}">${escapeHtml(source)}</pre>`;
+    }
+  },
+});
 
 let previewContainer: HTMLElement | null = null;
 let hoverButton: HTMLElement | null = null;
@@ -982,6 +1011,10 @@ function highlightCodeBlocks() {
   });
 }
 
+// Cancel any in-flight mermaid render whenever a fresh `updatePreview` runs —
+// only the latest call's diagrams should land in the DOM.
+let activeMermaidController: AbortController | null = null;
+
 export function updatePreview(content: string, comments: ReviewComment[]) {
   if (!previewContainer) return;
 
@@ -992,6 +1025,16 @@ export function updatePreview(content: string, comments: ReviewComment[]) {
 
   setupElementClickHandlers();
   setupHoverHandlers();
+
+  // Mermaid renders out-of-band so `updatePreview` stays synchronous and
+  // never blocks keystroke updates. The previous render (if any) is aborted
+  // so its DOM mutations can't clobber the latest content.
+  activeMermaidController?.abort();
+  activeMermaidController = new AbortController();
+  void renderMermaidBlocks(previewContainer, activeMermaidController.signal);
+
+  // hljs runs after — walkTokens already converted ```mermaid fences to html
+  // tokens, so there are no `language-mermaid` blocks for hljs to mangle.
   highlightCodeBlocks();
 }
 
@@ -1004,4 +1047,16 @@ export function scrollPreviewToComment(commentId: string) {
 
 export function getPreviewContainer(): HTMLElement | null {
   return previewContainer;
+}
+
+/**
+ * Re-render every mermaid diagram in the preview with the latest theme.
+ * Call from the theme toggle handler in main.ts.
+ */
+export function refreshMermaidForTheme(): void {
+  if (!previewContainer) return;
+  resetMermaidProcessed(previewContainer);
+  activeMermaidController?.abort();
+  activeMermaidController = new AbortController();
+  void renderMermaidBlocks(previewContainer, activeMermaidController.signal);
 }

--- a/file-review/src/mermaid.ts
+++ b/file-review/src/mermaid.ts
@@ -1,0 +1,164 @@
+/**
+ * Mermaid integration for the markdown preview.
+ *
+ * Lazy-loads the `mermaid` library on first use (so the bundler can split it
+ * into its own chunk), renders `<pre class="mermaid">` blocks to inline SVG,
+ * and re-renders idempotently when the preview is updated or theme is toggled.
+ *
+ * Design rules (see step-4 plan):
+ * - Render is fire-and-forget — `updatePreview` stays synchronous. Each call
+ *   passes an `AbortSignal`; only the latest call wins.
+ * - Sticky failure: if the dynamic import or initial setup fails, future
+ *   `getMermaid()` calls reject with a `MermaidLoadError` and we render a
+ *   `.mermaid-error` banner inline instead of looping forever.
+ * - Theme awareness: `mermaid.initialize` is called once on first import. If
+ *   the theme changes later, we re-initialize before the next `run` and
+ *   `resetMermaidProcessed` strips `data-processed` so the diagrams re-render.
+ */
+
+import type { default as MermaidAPI } from "mermaid";
+import type { Theme } from "./theme";
+
+type MermaidModule = typeof MermaidAPI;
+
+export class MermaidLoadError extends Error {
+  readonly cause?: unknown;
+  constructor(cause: unknown) {
+    super(`Mermaid failed to load: ${String(cause)}`);
+    this.name = "MermaidLoadError";
+    this.cause = cause;
+  }
+}
+
+let mermaidPromise: Promise<MermaidModule> | null = null;
+let mermaidLoadFailed = false;
+let lastAppliedTheme: Theme | null = null;
+let getThemeFn: () => Theme = () => "dark";
+
+/**
+ * Wire in the host's theme accessor. Called once at app boot from main.ts so
+ * mermaid can read the current theme without importing app state directly.
+ */
+export function initMermaid(getTheme: () => Theme): void {
+  getThemeFn = getTheme;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function mermaidThemeFor(theme: Theme): "dark" | "default" {
+  return theme === "dark" ? "dark" : "default";
+}
+
+/**
+ * Lazy-load mermaid. Subsequent calls return the cached promise.
+ * On first successful load, `mermaid.initialize` is called with the current
+ * theme. On any failure the loader becomes "stuck failed" — `MermaidLoadError`
+ * is thrown for every subsequent call until the page reloads.
+ */
+export async function getMermaid(): Promise<MermaidModule> {
+  if (mermaidLoadFailed) {
+    throw new MermaidLoadError("previous load attempt failed");
+  }
+  if (!mermaidPromise) {
+    mermaidPromise = import("mermaid")
+      .then((m) => {
+        const theme = getThemeFn();
+        m.default.initialize({
+          startOnLoad: false,
+          securityLevel: "strict",
+          theme: mermaidThemeFor(theme),
+        });
+        lastAppliedTheme = theme;
+        return m.default;
+      })
+      .catch((err) => {
+        mermaidLoadFailed = true;
+        mermaidPromise = null;
+        throw new MermaidLoadError(err);
+      });
+  }
+  return mermaidPromise;
+}
+
+/**
+ * Render every unprocessed `.mermaid` block in `container`. Idempotent — once
+ * mermaid stamps `data-processed="true"` on a node, we skip it on the next
+ * call. The `signal` short-circuits the work if a newer render has started.
+ */
+export async function renderMermaidBlocks(
+  container: HTMLElement,
+  signal?: AbortSignal,
+): Promise<void> {
+  const nodes = Array.from(
+    container.querySelectorAll<HTMLElement>(
+      '.mermaid:not([data-processed="true"])',
+    ),
+  );
+  if (nodes.length === 0) return;
+
+  let mermaid: MermaidModule;
+  try {
+    mermaid = await getMermaid();
+  } catch (err) {
+    if (err instanceof MermaidLoadError) {
+      const message = escapeHtml(String(err.cause ?? err.message));
+      for (const node of nodes) {
+        node.outerHTML =
+          `<div class="mermaid-error">Diagram rendering unavailable (${message})</div>`;
+      }
+      return;
+    }
+    console.error("mermaid getMermaid failed", err);
+    return;
+  }
+
+  if (signal?.aborted) return;
+
+  // Re-initialize if the theme changed since last load. Mermaid honors the new
+  // theme on the next `run` call.
+  const currentTheme = getThemeFn();
+  if (lastAppliedTheme !== currentTheme) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "strict",
+      theme: mermaidThemeFor(currentTheme),
+    });
+    lastAppliedTheme = currentTheme;
+  }
+
+  try {
+    await mermaid.run({ nodes, suppressErrors: true });
+  } catch (err) {
+    // suppressErrors keeps mermaid from throwing on per-diagram syntax errors;
+    // anything else here is unexpected.
+    console.error("mermaid.run failed", err);
+  }
+}
+
+/**
+ * Strip `data-processed` from every `.mermaid` node and restore the original
+ * source from `data-src` so the next `renderMermaidBlocks` re-renders them.
+ * Used by the theme toggle.
+ */
+export function resetMermaidProcessed(container: HTMLElement): void {
+  const nodes = container.querySelectorAll<HTMLElement>(".mermaid");
+  for (const node of nodes) {
+    const src = node.getAttribute("data-src");
+    if (src !== null) {
+      node.removeAttribute("data-processed");
+      try {
+        node.innerHTML = escapeHtml(decodeURIComponent(src));
+      } catch {
+        // Malformed data-src — leave node alone; mermaid.run will skip it
+        // because `data-processed` is now gone but innerHTML is unchanged.
+      }
+    }
+  }
+}

--- a/file-review/src/preview-nav.ts
+++ b/file-review/src/preview-nav.ts
@@ -1,3 +1,5 @@
+import type { Tab } from './tabs';
+
 const COMMENTABLE_SELECTOR = '[data-commentable="true"]';
 const DEFAULT_PAGE_SIZE = 5;
 
@@ -16,11 +18,16 @@ export class PreviewNavigator {
   constructor(
     private getPreviewContainer: () => HTMLElement | null,
     private getVimEnabled: () => boolean,
-    private onBlockActivated?: (el: HTMLElement) => void
+    private onBlockActivated?: (el: HTMLElement) => void,
+    // Reserved for step-2/3 — read active-tab state from inside the navigator.
+    // Defaults to a null accessor so existing call sites work.
+    private getActiveTab: () => Tab | null = () => null
   ) {
     this.keydownHandler = (e: KeyboardEvent) => this.handleKeydown(e);
     document.addEventListener('keydown', this.keydownHandler);
     this.wireSearchButtons();
+    // Mark `getActiveTab` as intentionally retained for forward-compat use.
+    void this.getActiveTab;
   }
 
   private isPreviewVisible(): boolean {

--- a/file-review/src/shortcuts.ts
+++ b/file-review/src/shortcuts.ts
@@ -12,7 +12,10 @@ export const shortcuts: Shortcut[] = [
   { keys: "⌘⇧Z", description: "Redo" },
   { keys: "⌘Q", description: "Quit application" },
   { keys: "⌘/", description: "Toggle shortcuts help" },
-  { keys: "⌘T", description: "Toggle theme (light/dark)" },
+  { keys: "⌘T", description: "New tab (open file)" },
+  { keys: "⌘W", description: "Close active tab" },
+  { keys: "⌘1…9", description: "Switch to Nth tab" },
+  { keys: "⌘⇧T", description: "Toggle theme (light/dark)" },
   { keys: "⌘M", description: "Toggle markdown view (raw/pretty)" },
   { keys: "⌘⇧V", description: "Toggle vim mode" },
   { keys: "⌘O", description: "Open file" },
@@ -127,7 +130,23 @@ export function hideShortcutsHelp() {
   helpModalVisible = false;
 }
 
-export function initShortcuts(handlers: Record<string, () => void>) {
+export interface ShortcutHandlers {
+  addComment?: () => void;
+  save?: () => void;
+  toggleTheme?: () => void;
+  toggleVim?: () => void;
+  toggleMarkdownView?: () => void;
+  openFile?: () => void;
+  newTab?: () => void;
+  closeTab?: () => void;
+  jumpToTab?: (n: number) => void;
+  zoomIn?: () => void;
+  zoomOut?: () => void;
+  undo?: () => void;
+  redo?: () => void;
+}
+
+export function initShortcuts(handlers: ShortcutHandlers) {
   document.addEventListener("keydown", (e) => {
     const isMeta = e.metaKey || e.ctrlKey;
     if (!isMeta) return;
@@ -147,6 +166,24 @@ export function initShortcuts(handlers: Record<string, () => void>) {
       return;
     }
 
+    // Tab management — must work even when CodeMirror has focus, so we
+    // route these BEFORE the editingText guard.
+    if (key === "w") {
+      e.preventDefault();
+      handlers.closeTab?.();
+      return;
+    }
+    if (key === "t" && !e.shiftKey) {
+      e.preventDefault();
+      handlers.newTab?.();
+      return;
+    }
+    if (/^[1-9]$/.test(e.key) && !e.shiftKey) {
+      e.preventDefault();
+      handlers.jumpToTab?.(parseInt(e.key, 10));
+      return;
+    }
+
     // In input/textarea/contenteditable, keep native text-editing shortcuts.
     if (editingText) {
       return;
@@ -158,7 +195,7 @@ export function initShortcuts(handlers: Record<string, () => void>) {
     } else if (e.key === "/") {
       e.preventDefault();
       showShortcutsHelp();
-    } else if (key === "t") {
+    } else if (key === "t" && e.shiftKey) {
       e.preventDefault();
       handlers.toggleTheme?.();
     } else if (key === "m") {

--- a/file-review/src/sidebar.ts
+++ b/file-review/src/sidebar.ts
@@ -1,27 +1,39 @@
 import type { ReviewComment } from "./comments";
 import { getEditorView } from "./editor";
+import type { Tab } from "./tabs";
 
 type CommentDeleteHandler = (commentId: string) => void;
 type CommentClickHandler = (comment: ReviewComment) => void;
 type CommentSubmitHandler = (text: string, lineNumber: number) => void;
 type CommentEditHandler = (commentId: string, newText: string) => void;
+type GetActiveTab = () => Tab | null;
 
 let deleteHandler: CommentDeleteHandler | null = null;
 let clickHandler: CommentClickHandler | null = null;
 let submitHandler: CommentSubmitHandler | null = null;
 let editHandler: CommentEditHandler | null = null;
+// Reserved for step-2/3 use; passed in at init for forward compatibility.
+let getActiveTab: GetActiveTab = () => null;
 let pendingLineNumber: number | null = null;
 
 export function initSidebar(
   onDelete: CommentDeleteHandler,
   onClick: CommentClickHandler,
   onSubmit: CommentSubmitHandler,
-  onEdit: CommentEditHandler
+  onEdit: CommentEditHandler,
+  activeTabAccessor: GetActiveTab
 ) {
   deleteHandler = onDelete;
   clickHandler = onClick;
   submitHandler = onSubmit;
   editHandler = onEdit;
+  getActiveTab = activeTabAccessor;
+}
+
+// Exported so step-2/3 can read active-tab state from sidebar internals if
+// needed; today this is a forward-compat hook.
+export function getActiveTabFromSidebar(): Tab | null {
+  return getActiveTab();
 }
 
 export function showCommentInput(lineNumber: number, label?: string) {

--- a/file-review/src/styles.css
+++ b/file-review/src/styles.css
@@ -1387,3 +1387,45 @@ body.light-theme #preview-container .hljs-operator { color: #1e1e1e; }
   font-weight: 600;
   margin-right: 8px;
 }
+
+/* Mermaid diagram blocks (rendered inline by mermaid.run from a `<pre class="mermaid">` placeholder).
+   Theme-aware backgrounds; SVG is centered horizontally. */
+#preview-container .mermaid {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: var(--bg-secondary, #1e1e1e);
+  border: 1px solid var(--border-color, #3c3c3c);
+  border-radius: 6px;
+  padding: 16px;
+  margin: 16px 0;
+  overflow-x: auto;
+  font-family: inherit;
+}
+
+#preview-container .mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
+body.light-theme #preview-container .mermaid {
+  background: #fafafa;
+  border-color: #e0e0e0;
+}
+
+/* Mermaid load/parse error UI — rendered when the library fails to load. */
+#preview-container .mermaid-error {
+  border: 1px solid #c0392b;
+  background: rgba(192, 57, 43, 0.08);
+  color: #c0392b;
+  font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  padding: 12px 16px;
+  margin: 16px 0;
+  border-radius: 6px;
+  white-space: pre-wrap;
+}
+
+body.light-theme #preview-container .mermaid-error {
+  background: rgba(192, 57, 43, 0.05);
+}

--- a/file-review/src/styles.css
+++ b/file-review/src/styles.css
@@ -126,6 +126,94 @@ body {
   font-size: 14px;
 }
 
+/* Tab strip */
+.tab-strip {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 1px;
+  padding: 0 8px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 32px;
+  scrollbar-width: thin;
+}
+
+.tab-strip:empty {
+  display: none;
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px 6px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-bottom: none;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  margin-top: 4px;
+  margin-bottom: -1px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  max-width: 240px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.tab:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.tab.active {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border-color: var(--border-color);
+}
+
+.tab-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.tab[data-dirty="true"] .tab-label::before {
+  content: "● ";
+  color: var(--accent-color);
+  font-size: 10px;
+}
+
+.tab-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--text-secondary);
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.tab:hover .tab-close,
+.tab.active .tab-close {
+  opacity: 1;
+}
+
+.tab-close:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
 /* Main container */
 #main-container {
   display: flex;

--- a/file-review/src/styles.css
+++ b/file-review/src/styles.css
@@ -1429,3 +1429,35 @@ body.light-theme #preview-container .mermaid {
 body.light-theme #preview-container .mermaid-error {
   background: rgba(192, 57, 43, 0.05);
 }
+
+/* Copy button on code blocks (preview pane) */
+#preview-container pre .code-copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-family: inherit;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+
+#preview-container pre:hover .code-copy-btn {
+  opacity: 1;
+}
+
+#preview-container pre .code-copy-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+#preview-container pre .code-copy-btn.copied {
+  opacity: 1;
+  color: #4ade80;
+  border-color: #4ade80;
+}

--- a/file-review/src/tabs-view.ts
+++ b/file-review/src/tabs-view.ts
@@ -1,0 +1,76 @@
+import type { Tab, TabManager } from "./tabs";
+
+export interface TabStripCallbacks {
+  /** User clicked a tab body to make it active. */
+  onActivate: (id: string) => void;
+  /** User clicked the X button on a tab. */
+  onClose: (id: string) => void;
+}
+
+/**
+ * Wire the tab strip DOM (`#tab-strip`) to a `TabManager`. Re-renders on
+ * every TabManager change. Hides itself when no tabs exist (CSS `:empty`).
+ */
+export function initTabStrip(
+  tabManager: TabManager,
+  callbacks: TabStripCallbacks
+): void {
+  const strip = document.getElementById("tab-strip");
+  if (!strip) return;
+
+  const render = () => {
+    const activeId = tabManager.activeId;
+    strip.innerHTML = "";
+
+    for (const tab of tabManager.tabs) {
+      strip.appendChild(renderTab(tab, tab.id === activeId, callbacks));
+    }
+  };
+
+  tabManager.subscribe(render);
+  render();
+}
+
+function renderTab(
+  tab: Tab,
+  isActive: boolean,
+  callbacks: TabStripCallbacks
+): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.className = "tab" + (isActive ? " active" : "");
+  btn.dataset.tabId = tab.id;
+  btn.dataset.dirty = String(tab.hasUnsavedChanges);
+  btn.setAttribute("role", "tab");
+  btn.setAttribute("aria-selected", String(isActive));
+
+  const label = document.createElement("span");
+  label.className = "tab-label";
+  label.textContent = tabLabel(tab);
+  label.title = tab.path ?? "(unsaved)";
+  btn.appendChild(label);
+
+  const close = document.createElement("span");
+  close.className = "tab-close";
+  close.textContent = "×"; // ×
+  close.setAttribute("role", "button");
+  close.setAttribute("aria-label", "Close tab");
+  btn.appendChild(close);
+
+  btn.addEventListener("click", (e) => {
+    const target = e.target as HTMLElement;
+    if (target.classList.contains("tab-close")) {
+      e.stopPropagation();
+      callbacks.onClose(tab.id);
+      return;
+    }
+    callbacks.onActivate(tab.id);
+  });
+
+  return btn;
+}
+
+function tabLabel(tab: Tab): string {
+  if (!tab.path) return "(unsaved)";
+  const parts = tab.path.split("/");
+  return parts[parts.length - 1] || tab.path;
+}

--- a/file-review/src/tabs.ts
+++ b/file-review/src/tabs.ts
@@ -1,0 +1,129 @@
+import type { ReviewComment } from "./comments";
+
+/**
+ * A pending preview-mode comment — the user clicked the "+" button on a
+ * preview block and we're waiting for them to type the comment text.
+ *
+ * Mirrors the shape used in `main.ts` before this refactor so we can drop
+ * it in without behavior change.
+ */
+export interface PendingPreviewComment {
+  sourceStart: number;
+  sourceEnd: number;
+  element: HTMLElement;
+}
+
+/**
+ * Per-tab state. Today (step-1) we render only one tab, but every field that
+ * used to be a module-scoped global in `main.ts` lives here so step-2 can
+ * activate multiple tabs without further plumbing.
+ *
+ * `cursor` and `scrollTop` are reserved for step-3 — they're optional today.
+ */
+export interface Tab {
+  id: string;
+  path: string | null;
+  comments: ReviewComment[];
+  isMarkdownFile: boolean;
+  isRawMode: boolean;
+  hasUnsavedChanges: boolean;
+  lastSavedSnapshot: string;
+  pendingPreviewComment: PendingPreviewComment | null;
+  cursor?: { from: number; to: number };
+  scrollTop?: number;
+}
+
+export type TabSubscriber = () => void;
+
+/**
+ * Pure data layer for tabs. No DOM, no Tauri calls. `tabs-view.ts` owns
+ * rendering; `main.ts` owns the lifecycle and bridges to the editor /
+ * preview / sidebar singletons.
+ */
+export class TabManager {
+  tabs: Tab[] = [];
+  activeId: string | null = null;
+  private subscribers: Set<TabSubscriber> = new Set();
+
+  /** Returns the active tab, or null if no tabs are open. */
+  getActive(): Tab | null {
+    if (!this.activeId) return null;
+    return this.tabs.find((t) => t.id === this.activeId) ?? null;
+  }
+
+  /**
+   * Add a new tab. If `makeActive` is true (default), activates it.
+   * Tab IDs are generated via `crypto.randomUUID()`.
+   */
+  add(init: Omit<Tab, "id">, makeActive = true): Tab {
+    const tab: Tab = { id: crypto.randomUUID(), ...init };
+    this.tabs.push(tab);
+    if (makeActive) {
+      this.activeId = tab.id;
+    }
+    this.notify();
+    return tab;
+  }
+
+  /**
+   * Remove a tab. If the removed tab was active, fall back to the previous
+   * tab in the list (or null if none remain).
+   */
+  remove(id: string): void {
+    const idx = this.tabs.findIndex((t) => t.id === id);
+    if (idx < 0) return;
+
+    this.tabs.splice(idx, 1);
+
+    if (this.activeId === id) {
+      if (this.tabs.length === 0) {
+        this.activeId = null;
+      } else {
+        // Prefer the tab that was just to the left; if we removed index 0,
+        // use the new index 0 (which was previously index 1).
+        const newIdx = Math.max(0, idx - 1);
+        this.activeId = this.tabs[newIdx].id;
+      }
+    }
+
+    this.notify();
+  }
+
+  /** Make `id` active. No-op if `id` doesn't match a tab. */
+  setActive(id: string): void {
+    if (this.activeId === id) return;
+    if (!this.tabs.some((t) => t.id === id)) return;
+    this.activeId = id;
+    this.notify();
+  }
+
+  /**
+   * Patch fields on the tab with the given `id`. Returns the updated tab
+   * or null if the id was not found.
+   */
+  update(id: string, patch: Partial<Tab>): Tab | null {
+    const tab = this.tabs.find((t) => t.id === id);
+    if (!tab) return null;
+    Object.assign(tab, patch);
+    this.notify();
+    return tab;
+  }
+
+  /**
+   * Subscribe to tab-list / active-tab changes. Returns an unsubscribe fn.
+   * Listeners are called synchronously after every mutation — render code
+   * should be cheap and idempotent.
+   */
+  subscribe(listener: TabSubscriber): () => void {
+    this.subscribers.add(listener);
+    return () => {
+      this.subscribers.delete(listener);
+    };
+  }
+
+  private notify(): void {
+    for (const listener of this.subscribers) {
+      listener();
+    }
+  }
+}

--- a/file-review/src/tabs.ts
+++ b/file-review/src/tabs.ts
@@ -14,15 +14,20 @@ export interface PendingPreviewComment {
 }
 
 /**
- * Per-tab state. Today (step-1) we render only one tab, but every field that
- * used to be a module-scoped global in `main.ts` lives here so step-2 can
- * activate multiple tabs without further plumbing.
- *
- * `cursor` and `scrollTop` are reserved for step-3 — they're optional today.
+ * Per-tab state. Step-2 activates multiple tabs by snapshotting the active
+ * tab's editor content into `doc` before swapping. `cursor` and `scrollTop`
+ * are reserved for step-3 — they're optional today.
  */
 export interface Tab {
   id: string;
   path: string | null;
+  /**
+   * In-memory editor content (clean content with comment markers stripped).
+   * Source of truth for tab content once a tab exists — `loadFile` seeds it
+   * from disk; `snapshotActiveDoc()` (in `main.ts`) updates it on every
+   * tab switch so dirty edits survive.
+   */
+  doc: string;
   comments: ReviewComment[];
   isMarkdownFile: boolean;
   isRawMode: boolean;
@@ -36,6 +41,17 @@ export interface Tab {
 export type TabSubscriber = () => void;
 
 /**
+ * Fired when the active tab changes (or is set/cleared). `from` is the
+ * outgoing tab id (null on first activation), `to` is the incoming.
+ * Subscribers run synchronously *before* `notify()` fires the regular
+ * subscribers — gives callers a chance to snapshot outgoing tab state.
+ */
+export type ActiveChangeSubscriber = (
+  from: string | null,
+  to: string | null
+) => void;
+
+/**
  * Pure data layer for tabs. No DOM, no Tauri calls. `tabs-view.ts` owns
  * rendering; `main.ts` owns the lifecycle and bridges to the editor /
  * preview / sidebar singletons.
@@ -44,11 +60,17 @@ export class TabManager {
   tabs: Tab[] = [];
   activeId: string | null = null;
   private subscribers: Set<TabSubscriber> = new Set();
+  private activeChangeSubscribers: Set<ActiveChangeSubscriber> = new Set();
 
   /** Returns the active tab, or null if no tabs are open. */
   getActive(): Tab | null {
     if (!this.activeId) return null;
     return this.tabs.find((t) => t.id === this.activeId) ?? null;
+  }
+
+  /** Find tab by path (first match). null if no match. */
+  findByPath(path: string): Tab | null {
+    return this.tabs.find((t) => t.path === path) ?? null;
   }
 
   /**
@@ -59,7 +81,9 @@ export class TabManager {
     const tab: Tab = { id: crypto.randomUUID(), ...init };
     this.tabs.push(tab);
     if (makeActive) {
+      const prev = this.activeId;
       this.activeId = tab.id;
+      this.notifyActiveChange(prev, tab.id);
     }
     this.notify();
     return tab;
@@ -76,6 +100,7 @@ export class TabManager {
     this.tabs.splice(idx, 1);
 
     if (this.activeId === id) {
+      const prev = this.activeId;
       if (this.tabs.length === 0) {
         this.activeId = null;
       } else {
@@ -84,16 +109,19 @@ export class TabManager {
         const newIdx = Math.max(0, idx - 1);
         this.activeId = this.tabs[newIdx].id;
       }
+      this.notifyActiveChange(prev, this.activeId);
     }
 
     this.notify();
   }
 
-  /** Make `id` active. No-op if `id` doesn't match a tab. */
+  /** Make `id` active. No-op if `id` doesn't match a tab or is already active. */
   setActive(id: string): void {
     if (this.activeId === id) return;
     if (!this.tabs.some((t) => t.id === id)) return;
+    const prev = this.activeId;
     this.activeId = id;
+    this.notifyActiveChange(prev, id);
     this.notify();
   }
 
@@ -121,9 +149,28 @@ export class TabManager {
     };
   }
 
+  /**
+   * Subscribe to *active-tab* changes only. Fires synchronously *before*
+   * regular `subscribe()` listeners — use this to snapshot outgoing tab
+   * state (e.g. editor doc / cursor / scroll) before the next tab paints.
+   * Does NOT fire for tab-list mutations that don't change the active id.
+   */
+  subscribeActiveChange(listener: ActiveChangeSubscriber): () => void {
+    this.activeChangeSubscribers.add(listener);
+    return () => {
+      this.activeChangeSubscribers.delete(listener);
+    };
+  }
+
   private notify(): void {
     for (const listener of this.subscribers) {
       listener();
+    }
+  }
+
+  private notifyActiveChange(from: string | null, to: string | null): void {
+    for (const listener of this.activeChangeSubscribers) {
+      listener(from, to);
     }
   }
 }

--- a/file-review/src/toc.ts
+++ b/file-review/src/toc.ts
@@ -1,11 +1,26 @@
 import { marked } from 'marked';
 import { slugify } from './markdown-preview';
+import type { Tab } from './tabs';
 
 export interface TocEntry {
   text: string;
   depth: number;
   id: string;
   sourcePos: number;
+}
+
+// Reserved for step-2/3: ToC currently re-renders from `main.ts`-supplied
+// entries. The accessor is passed in at startup so future per-tab ToC caching
+// can read `path`/`comments` directly.
+let getActiveTab: () => Tab | null = () => null;
+
+export function initToc(activeTabAccessor: () => Tab | null) {
+  getActiveTab = activeTabAccessor;
+}
+
+// Forward-compat hook for step-2/3.
+export function getActiveTabFromToc(): Tab | null {
+  return getActiveTab();
 }
 
 export function extractTocEntries(content: string): TocEntry[] {

--- a/file-review/test-files/with-mermaid.md
+++ b/file-review/test-files/with-mermaid.md
@@ -1,0 +1,81 @@
+# Mermaid Diagram Test Fixture
+
+This file exercises the inline mermaid renderer added in step-4. It mixes
+several mermaid diagram kinds with one intentionally broken block (to
+verify the error UI) and a couple of regular code fences (to confirm
+hljs still styles them).
+
+## 1. Flowchart (graph TD)
+
+A simple top-down DAG, the most common case in our `v-plan` outputs.
+
+```mermaid
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Run step]
+    B -->|No| D[Skip]
+    C --> E[End]
+    D --> E
+```
+
+## 2. Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Tauri
+    User->>CLI: file-review foo.md
+    CLI->>Tauri: spawn window
+    Tauri-->>User: render preview
+```
+
+## 3. Class diagram
+
+```mermaid
+classDiagram
+    class Tab {
+        +string id
+        +string path
+        +string doc
+        +ReviewComment[] comments
+    }
+    class TabManager {
+        +add(tab) Tab
+        +remove(id) void
+        +getActive() Tab
+    }
+    TabManager "1" o-- "*" Tab
+```
+
+## 4. Intentionally broken — should render as an error block
+
+```mermaid
+this is not valid mermaid syntax !!!
+graph -- nope
+```
+
+## 5. Normal fences (hljs should still highlight these)
+
+A TypeScript snippet:
+
+```typescript
+export function hello(name: string): string {
+  return `Hello, ${name}!`;
+}
+```
+
+A Bash snippet:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+echo "build complete"
+```
+
+## Notes
+
+- Switching theme (Cmd+Shift+T) should re-render every diagram with the new
+  palette without leaving stale SVGs behind.
+- Editing a single character in any mermaid block above should re-render the
+  edited block within ~150ms with no flicker and no double-rendering.

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/root.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/root.md
@@ -4,7 +4,7 @@ author: Taras
 plan_type: dag
 status: in-progress
 last_updated: 2026-04-28
-last_updated_by: Taras
+last_updated_by: Claude (v-implementing)
 ---
 
 # file-review: Multi-file Tabs + Mermaid Rendering — Plan (DAG)

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/root.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/root.md
@@ -1,0 +1,171 @@
+---
+date: 2026-04-28T00:00:00-00:00
+author: Taras
+plan_type: dag
+status: in-progress
+last_updated: 2026-04-28
+last_updated_by: Taras
+---
+
+# file-review: Multi-file Tabs + Mermaid Rendering — Plan (DAG)
+
+## Overview
+
+Add two independent capabilities to `file-review/`:
+
+1. **Multi-file tabs** — open multiple files in one window, switch between them, close individually, with per-tab dirty/comment state.
+2. **Mermaid diagram rendering** — render ` ```mermaid ` fenced blocks as live SVG inside the markdown preview pane, in addition to existing highlight.js code blocks.
+
+- **Motivation**: Reviewers currently have to relaunch `file-review` per file (slow context switch), and v-planning produces plans with mermaid DAGs that today render as raw code in the preview pane. Both gaps make the tool feel single-purpose.
+- **Related**: `file-review/src/main.ts`, `file-review/src/markdown-preview.ts`, `file-review/src/editor.ts`, `file-review/src-tauri/src/main.rs`
+
+## Current State Analysis
+
+**Document model is implicit, scattered across module-scoped globals.** No `OpenFile` / `Tab` object exists today. The "currently open file" lives in:
+
+- `src/main.ts:55-72` — `currentFilePath`, `comments`, `isMarkdownFile`, `isRawMode`, `hasUnsavedChanges`, `lastSavedSnapshot`, `pendingPreviewComment`
+- `src/editor.ts:15-19` — `editorView` plus `themeCompartment` / `vimCompartment` / `fontSizeCompartment` / `keymapCompartment` (all module-scoped)
+- `src/markdown-preview.ts:39-44` — `previewContainer`, `hoverButton`, `currentHoverElement`, `addCommentCallback`, `hoverListenersAttached`, `hideTimeout`
+- `src/sidebar.ts:9-13`, `src/toc.ts:35`, `src/main.ts:65` (`previewNav`)
+- Rust mirror: `AppState.current_file: Mutex<Option<PathBuf>>` and `AppState.original_content: Mutex<Option<String>>` — `src-tauri/src/lib.rs:181-187`
+
+**Open-file flow** — `showFilePickerAndLoad` (`src/main.ts:490`) → `loadFile(path)` (`src/main.ts:689`):
+1. `API.readFile(path)` → `file_ops::read_file`
+2. `parseAndStripComments()` (`src/comments.ts:201`) splits content/comments
+3. Globals updated; `API.setCurrentFile(path)` syncs Rust state
+4. `setEditorContent()` (under `withSuppressedCommentSync`) — avoids re-mapping
+5. `renderCommentState()` → preview + ToC + CM highlights
+6. `updateViewMode()` toggles editor vs preview
+
+The unsaved-changes guard at `src/main.ts:491` is the natural fork point for "open in new tab vs replace".
+
+**DOM layout** (`index.html`) — vanilla CSS, flex column `#app`:
+- `#toolbar` (lines 11-40)
+- `#main-container` (line 41) — flex row with three siblings: `#editor-container`, `#preview-wrapper` (`flex: 7`, contains `#preview-search-bar` + `#preview-container`), `#sidebar`
+- Tab strip lands between `#toolbar` and `#main-container`. CSS uses custom properties for theme tokens (`src/styles.css:7-36`).
+
+**Markdown preview pipeline** — `updatePreview(content, comments)` at `src/markdown-preview.ts:971-982`:
+- `renderMarkdown()` parses frontmatter → `injectHighlightSpans` (review markers) → `collectCommentableRanges` → `marked.parse()` with custom renderer (heading IDs, per-line splits)
+- `previewContainer.innerHTML = html` at line 975
+- `setCommentableAttributes` + `applyCommentHighlights` post-insert
+- `highlightCodeBlocks()` (line 963) runs hljs on every `pre code`
+
+**Mermaid integration point**: extend `updatePreview` after innerHTML at line 981 with a sibling `renderMermaidBlocks()` that runs **before** `highlightCodeBlocks()` — otherwise hljs wraps mermaid source in `<span>` tokens and breaks parsing. Use a marked extension to emit `<pre class="mermaid" data-src="<encoded-source>">` placeholders, then `mermaid.run({ querySelector: '.mermaid:not([data-processed="true"])', suppressErrors: true })` for idempotent re-renders on every keystroke.
+
+**Shortcut conflicts** (`src/shortcuts.ts:130-187` — single global `keydown`):
+- `Cmd+T` is **already bound** to toggle theme — must move theme to `Cmd+Shift+T` to free `Cmd+T`/`Cmd+N` for "new tab"
+- `Cmd+W` not currently bound (Tauri default closes window) — intercept
+- `Cmd+1..9` — `editingText` early-return at line 151 will swallow them when CodeMirror has focus; digit check needs to move above the guard
+
+**Save / dirty state** — single global `hasUnsavedChanges` (`src/main.ts:63`); `syncUnsavedChangesState` (line 117) recomputes on every doc change. Cmd+S → `saveFile()` (line 784) → `getSerializedContentForPersistence()` → `API.writeFile()` → `markSnapshotAsSaved()`. Tauri menu accelerator `CmdOrCtrl+S` at `src-tauri/src/lib.rs:42-50` fires `menu:save` event listened at `src/main.ts:249-251`.
+
+**Comment-export-on-close** (`src-tauri/src/lib.rs:110-176`) — `WindowEvent::CloseRequested` reads `state.current_file` from disk, runs `parse_comments_for_output`, prints to stdout. **Today this is single-file**. With tabs, JS must flush all dirty tabs before close, and Rust needs a multi-file export path (or JS sends serialized comments per file before close fires).
+
+**Hard singletons that resist a `fileId` parameterization** (must be addressed in step-1):
+- `editorView` and CM compartments (`src/editor.ts`)
+- `previewContainer` (`src/markdown-preview.ts`)
+- `previewNav` (`src/main.ts:65`)
+- Many `getElementById` calls assume a unique editor / preview / sidebar / toc panel — fine if we keep one editor pane and swap state on tab activation, but each tab needs its own state struct.
+
+**`comments.ts` is pure** — unaffected by the refactor.
+
+## Desired End State
+
+- Reviewer launches `file-review fileA.md fileB.md` (or opens additional files via cmd+O / drag-drop) and sees a tab strip above the editor pane. Clicking a tab switches the editor + preview + sidebar/TOC + comments without losing per-file state. cmd+W closes the active tab; cmd+1..9 jumps to a tab; if all tabs close the window stays open with an empty state.
+- Markdown previews render ` ```mermaid ` blocks as inline SVG, theme-aware (light/dark), with friendly error messaging on bad syntax. Existing highlight.js fences for other languages still work. Re-renders on every keystroke don't accumulate or double-render.
+- Existing `/file-review:process-comments` flow (read HTML comment markers from the file) keeps working — per-tab.
+
+## What We're NOT Doing
+
+- No file tree / folder browser in the sidebar (out of scope; tabs only).
+- No persistent session restore across launches (no "reopen last session").
+- No drag-to-reorder tabs (nice-to-have, deferred).
+- No mermaid editing UX (live syntax assist, palette). Just rendering.
+- No per-tab vim-mode toggle; vim setting stays global.
+
+## Implementation Approach
+
+- **Tabs split into 3 vertical slices.** Step 1: refactor singletons into a `TabManager` *and* render the tab strip showing one tab — visible, QA-able. Step 2: actually open multiple files (CLI args + cmd+O appending + drag-drop) and switch between them. Step 3: per-tab state preservation (cursor, scroll, dirty, comments) and multi-file comment-export-on-close.
+- **Mermaid is independent of tabs.** Touches only `markdown-preview.ts` plus a new `mermaid.ts` module — runs as a parallel DAG branch.
+- **One editor + one preview pane, swap state on activation.** Avoids per-tab CodeMirror instances (heavy memory, complex compartments). The active tab's state hydrates the singletons; on switch we save current state into the outgoing tab and load the incoming.
+- **Mermaid pipeline order matters.** `renderMermaidBlocks()` must run *before* `highlightCodeBlocks()` — otherwise hljs munges the mermaid source.
+- **Final integration step verifies both features compose** — open two markdown files with mermaid blocks, switch tabs, confirm per-tab preview, comments, and dirty state survive.
+
+## Quick Verification Reference
+
+- Typecheck: `cd file-review && bun run check`
+- Build: `cd file-review && bun run build`
+- Dev (web/browser): `cd file-review && bun run dev:web`
+- Dev (Tauri): `cd file-review && bun run dev`
+- E2E smoke: `bun run dev -- file-review/test-files/sample.md`
+
+## DAG
+
+```mermaid
+graph TD
+    step-1[step-1: TabManager refactor + single-tab strip]
+    step-2[step-2: Multi-file open + switch + close]
+    step-3[step-3: Per-tab state preservation + multi-file export]
+    step-4[step-4: Mermaid rendering in preview]
+    step-5[step-5: Integration + cross-cutting QA]
+    step-1 --> step-2
+    step-2 --> step-3
+    step-3 --> step-5
+    step-4 --> step-5
+```
+
+## Steps
+
+| ID | Name | Depends on | Status | File |
+|----|------|------------|--------|------|
+| step-1 | TabManager refactor + single-tab strip | — | ready | [step-1.md](./step-1.md) |
+| step-2 | Multi-file open + switch + close | step-1 | ready | [step-2.md](./step-2.md) |
+| step-3 | Per-tab state preservation + multi-file export | step-2 | ready | [step-3.md](./step-3.md) |
+| step-4 | Mermaid rendering in preview | — | ready | [step-4.md](./step-4.md) |
+| step-5 | Integration + cross-cutting QA | step-3, step-4 | ready | [step-5.md](./step-5.md) |
+
+> **Canonical dependencies and execution status live in each `step-<n>.md`'s frontmatter.** This table is a derived snapshot at plan creation. During `/v-implement`, frontmatter `status` (`ready` → `claimed` → `done`) is the source of truth — re-render this table when you want a current view.
+
+## Pre-flight Verification
+
+Run before kicking off any step:
+
+- [ ] Working tree is clean (or only contains intentional in-flight work)
+- [ ] Baseline typecheck passes: `cd file-review && bun run check`
+- [ ] Baseline build passes: `cd file-review && bun run build`
+- [ ] `bun install` ran cleanly and `node_modules/` is fresh
+- [ ] `cd file-review && bun run dev:web` launches the app on a sample file with no console errors
+
+## Global Verification
+
+Run after all steps complete (final wave gate):
+
+- [ ] Whole-repo typecheck: `cd file-review && bun run check`
+- [ ] Production build passes: `cd file-review && bun run build`
+- [ ] `file-review file-review/test-files/sample.md file-review/test-files/with-mermaid.md` opens both in tabs; preview pane of the mermaid file renders SVG diagrams; switching tabs preserves cursor/scroll/dirty/comment state per tab; cmd+W closes active tab; cmd+1..9 selects nth tab
+- [ ] `/file-review:process-comments` round-trip still works on a file opened in a multi-tab session
+- [ ] No regressions in vim mode, comment markers, save shortcut, or theme toggle
+
+## Appendix
+
+- **Follow-up plans**: file-tree sidebar; session restore; drag-reorder tabs; mermaid live-edit assist
+- **Derail notes**: consider extracting `markdown-preview.ts` post-process pipeline to support future plugins (mermaid is the first non-highlight transform — second one would justify abstraction)
+- **References**:
+  - `file-review/src/main.ts`, `file-review/src/markdown-preview.ts`, `file-review/src/editor.ts`
+  - mermaid v11 docs: https://mermaid.js.org/config/usage, https://github.com/mermaid-js/mermaid/issues/2972 (marked integration)
+
+## Review Errata
+
+_Reviewed: 2026-04-28 by Claude (autopilot). All findings resolved 2026-04-28._
+
+### Resolved
+- [x] **step-2 will lose dirty edits on tab switch.** Resolved: step-2 now adds a `Tab.doc` field, a `snapshotActiveDoc()` helper, and a `tabManager.subscribe({ from, to })` hook that snapshots the outgoing tab's doc before activating the incoming. Step-3 promotes the helper to also snapshot cursor/scroll. Step-2 QA bucket adds an explicit dirty-edit-preservation regression test.
+- [x] **`updatePreview` going async will block keystroke renders.** Resolved: step-4 keeps `updatePreview` synchronous. `renderMermaidBlocks` is fire-and-forget with an `AbortController` — each call cancels any in-flight render so only the latest update wins.
+- [x] **Pushing all tab content to Rust on every save is wasteful.** Resolved: step-3 narrows `pushTabStatesToRust()` to fire only on tab-close + window-close — never on save or switch.
+- [x] **`serialize` function referenced but undefined.** Resolved: step-3 pins to `serializeComments(t.doc, t.comments)` from `comments.ts` throughout.
+- [x] **Mermaid lib load failure unaddressed.** Resolved: step-4's `getMermaid()` introduces `MermaidLoadError`, sets a sticky `mermaidLoadFailed` flag, and `renderMermaidBlocks` catches the error to render a `mermaid-error` banner inline without breaking the rest of the markdown render.
+- [x] **Step-1 vague on comment-plumbing refactor.** Resolved: step-1 commits to passing a `getActiveTab` accessor into `initPreview` / `initSidebar` / `initToc` / `PreviewNavigator` constructors at startup. The `addCommentCallback` channel stays; its handler is the only place that mutates comments via `writeActive`.
+- [x] **Step-4 punts marked-extension implementation.** Resolved: step-4 commits to the `walkTokens` approach with a concrete code snippet that mutates mermaid `code` tokens into `html` tokens at parse time, bypassing both `marked`'s code renderer and hljs.
+- [x] **Tauri 2 drag-drop event name.** Resolved: step-2 specifies `getCurrentWebview().onDragDropEvent` from `@tauri-apps/api/webview` (Tauri 2's API, not v1's `tauri://file-drop`), with HTML5 drop as the `dev:web` fallback.
+- [x] step-4: contradictory line-reference for highlight-vs-mermaid ordering — clarified that mermaid runs after innerHTML write and before hljs.
+- [x] step-5: missing Cargo.lock follow-up commit per project CLAUDE.md release process.

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/root.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/root.md
@@ -2,7 +2,7 @@
 date: 2026-04-28T00:00:00-00:00
 author: Taras
 plan_type: dag
-status: in-progress
+status: completed
 last_updated: 2026-04-28
 last_updated_by: Claude (v-implementing)
 ---

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-1.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-1.md
@@ -1,0 +1,99 @@
+---
+id: step-1
+name: TabManager refactor + single-tab strip
+depends_on: []
+status: ready
+---
+
+<!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
+working, then transitions `status` to `done` (success) or back to `ready` (retry-able failure). -->
+
+# step-1: TabManager refactor + single-tab strip
+
+## Overview
+
+Introduce an explicit `Tab` model and `TabManager` that owns what is today scattered across module-scoped globals (`currentFilePath`, `comments`, `hasUnsavedChanges`, `lastSavedSnapshot`, `isMarkdownFile`, `isRawMode`, `pendingPreviewComment`). Render a tab strip above `#main-container` that shows the single active tab with the file's basename + dirty indicator. Keep one `editorView` and one `previewContainer` — they always reflect the active tab. **No multi-file behavior yet** — opening a file still replaces (we make multi-file work in step-2). After this step, the user sees a tab bar with one tab and a close button (closing returns to the empty state) — every other behavior is byte-for-byte identical to today.
+
+## Changes Required:
+
+#### 1. New: TabManager module
+
+**File**: `file-review/src/tabs.ts` (new)
+**Changes**:
+- Export `interface Tab { id: string; path: string | null; comments: ReviewComment[]; isMarkdownFile: boolean; isRawMode: boolean; hasUnsavedChanges: boolean; lastSavedSnapshot: string; pendingPreviewComment: PendingPreviewComment | null; cursor?: { from: number; to: number }; scrollTop?: number; }`
+- Export `class TabManager` with: `tabs: Tab[]`, `activeId: string | null`, `getActive()`, `add(tab)`, `remove(id)`, `setActive(id)`, `update(id, patch)`, `subscribe(listener)` (event-bus for tab list / active changes).
+- Use `crypto.randomUUID()` for tab IDs.
+- Pure data layer — no DOM, no Tauri calls.
+
+#### 2. Wire TabManager through main.ts
+
+**File**: `file-review/src/main.ts`
+**Changes**:
+- Replace globals at lines 55-72 with a single `tabManager = new TabManager()` import.
+- Add helpers `readActive()` / `writeActive(patch)` that proxy to `tabManager.getActive()` and `tabManager.update(active.id, patch)`.
+- Replace every read of `currentFilePath` / `comments` / `hasUnsavedChanges` / `lastSavedSnapshot` / `isMarkdownFile` / `isRawMode` / `pendingPreviewComment` with `readActive().<field>`.
+- Replace every assignment with `writeActive({ field: value })`.
+- `loadFile(path)` (line 689): if no tabs, create one via `tabManager.add({ path, ... })`; else `tabManager.update(activeId, { path, ... })` (replace-in-active-tab — multi-tab open lands in step-2).
+- `closeActiveTab()`: new helper. If only one tab, remove it and show empty state. Wire to a new `#tab-close-active` button on the strip and a placeholder noop for now.
+
+#### 3. Tab strip DOM + render
+
+**File**: `file-review/index.html`
+**Changes**:
+- Insert `<div id="tab-strip" class="tab-strip" role="tablist"></div>` between the closing `</div>` of `#toolbar` (line 40) and `<div id="main-container">` (line 41).
+
+**File**: `file-review/src/styles.css`
+**Changes**:
+- Add `.tab-strip` (flex row, scrollable horizontally, theme-aware bg/border), `.tab` (padding, dirty-dot pseudo-element when `[data-dirty="true"]`), `.tab.active` (highlighted), `.tab-close` (X button, hover only), `.tab-strip:empty` → `display: none`.
+- Use existing CSS custom properties (`--bg-secondary`, `--border-color`, etc.).
+
+**File**: `file-review/src/tabs-view.ts` (new)
+**Changes**:
+- Export `initTabStrip(tabManager)` that subscribes to `tabManager` and renders `<button class="tab" data-tab-id="<id>" data-dirty="<bool>" role="tab" aria-selected="<bool>"><span class="tab-label">basename</span><span class="tab-close">×</span></button>` per tab into `#tab-strip`.
+- Click on tab → `tabManager.setActive(id)`.
+- Click on `.tab-close` → `closeTab(id)` (stops propagation; in step-1 only the active tab can be closed; step-2 enables close any).
+- For now, hide strip when 0 tabs (CSS `:empty`); show when 1+.
+
+#### 4. Refactor editor.ts to remove implicit-active-file assumption
+
+**File**: `file-review/src/editor.ts`
+**Changes**:
+- No structural change to `editorView` (still one instance) — but document with comment that the editor's content is always "the active tab's content". The `setEditorContent(content)` and `getEditorContent()` helpers stay.
+- Add `getEditorState() → { cursor, scrollTop }` and `setEditorState({ cursor?, scrollTop? })` for step-3 to call (used during tab activation).
+
+#### 5. Refactor markdown-preview.ts/sidebar.ts/toc.ts/preview-nav.ts comment plumbing
+
+**File**: `file-review/src/markdown-preview.ts`, `file-review/src/sidebar.ts`, `file-review/src/toc.ts`, `file-review/src/preview-nav.ts`
+**Changes**:
+- **Approach (chosen)**: pass a `getActiveTab: () => Tab | null` accessor (closing over `tabManager`) into `initPreview`, `initSidebar`, `initToc`, and `PreviewNavigator`'s constructor — once, at startup. Each module calls `getActiveTab()` whenever it needs `comments` or `path`. Keeps function signatures of internal helpers unchanged; only the init/constructor signatures gain one parameter.
+- The existing `addCommentCallback` global in `markdown-preview.ts:39` stays as the "user added a comment" event channel — but its handler in `main.ts` now writes via `writeActive({ comments: [...readActive().comments, newComment] })` instead of mutating a free variable.
+- The `pendingLineNumber` flag in `sidebar.ts:9` becomes a local in `initSidebar`'s closure (it was always per-instance — no semantic change, just stops looking like a global).
+
+#### 6. CLI args / launch path: seed first tab
+
+**File**: `file-review/src/main.ts`
+**Changes**:
+- The startup path that reads CLI args (Tauri side passes path to JS; today it triggers `loadFile`) — wrap so the tab gets created via `tabManager.add(...)` instead of mutating globals.
+
+### Success Criteria:
+
+*(Push everything you can into the first two buckets — Automated Verification + Automated QA — so the agent provides proof of work. Manual Verification is the exception, not the default.)*
+
+#### Automated Verification:
+- [ ] Typecheck passes: `cd file-review && bun run check`
+- [ ] Build passes: `cd file-review && bun run build`
+- [ ] No `any` types introduced in `tabs.ts` or `tabs-view.ts`
+- [ ] `grep -rE 'let (currentFilePath|hasUnsavedChanges|lastSavedSnapshot|isMarkdownFile|isRawMode|pendingPreviewComment)\s*[=:]' file-review/src/` returns only matches inside `tabs.ts` (i.e. all the old module-globals are gone from `main.ts`)
+
+#### Automated QA:
+- [ ] Sub-agent launches `bun run dev:web file-review/test-files/sample.md`, takes a screenshot, confirms: tab bar visible above editor pane with one tab labeled `sample.md`, no console errors, editor content matches the file
+- [ ] Sub-agent clicks the tab's `×` close button, confirms editor empties to the existing empty state and tab bar hides
+- [ ] Sub-agent re-opens the file via the toolbar "Open" button, confirms a new tab appears (replaces old empty state) — single-tab semantics preserved
+- [ ] Sub-agent edits one character, confirms the tab gets a `data-dirty="true"` attribute and visible dirty indicator; cmd+S clears it
+
+#### Manual Verification:
+- [ ] Tab strip styling looks coherent with the rest of the toolbar/sidebar in both light and dark themes
+- [ ] No visual jank when transitioning empty-state → file-loaded → empty-state
+- [ ] Vim mode, comment markers, save shortcut, and existing toolbar buttons all behave exactly as before
+
+**Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. After verification passes, commit with `[step-1] Introduce TabManager + single-tab strip`.

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-1.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-1.md
@@ -2,7 +2,9 @@
 id: step-1
 name: TabManager refactor + single-tab strip
 depends_on: []
-status: ready
+status: done
+assignee:
+claimed_at:
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -80,10 +82,10 @@ Introduce an explicit `Tab` model and `TabManager` that owns what is today scatt
 *(Push everything you can into the first two buckets — Automated Verification + Automated QA — so the agent provides proof of work. Manual Verification is the exception, not the default.)*
 
 #### Automated Verification:
-- [ ] Typecheck passes: `cd file-review && bun run check`
-- [ ] Build passes: `cd file-review && bun run build`
-- [ ] No `any` types introduced in `tabs.ts` or `tabs-view.ts`
-- [ ] `grep -rE 'let (currentFilePath|hasUnsavedChanges|lastSavedSnapshot|isMarkdownFile|isRawMode|pendingPreviewComment)\s*[=:]' file-review/src/` returns only matches inside `tabs.ts` (i.e. all the old module-globals are gone from `main.ts`)
+- [x] Typecheck passes: `cd file-review && bun run check`
+- [x] Build passes: `cd file-review && bun run build`
+- [x] No `any` types introduced in `tabs.ts` or `tabs-view.ts`
+- [x] `grep -rE 'let (currentFilePath|hasUnsavedChanges|lastSavedSnapshot|isMarkdownFile|isRawMode|pendingPreviewComment)\s*[=:]' file-review/src/` returns only matches inside `tabs.ts` (i.e. all the old module-globals are gone from `main.ts`)
 
 #### Automated QA:
 - [ ] Sub-agent launches `bun run dev:web file-review/test-files/sample.md`, takes a screenshot, confirms: tab bar visible above editor pane with one tab labeled `sample.md`, no console errors, editor content matches the file

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-2.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-2.md
@@ -2,7 +2,9 @@
 id: step-2
 name: Multi-file open + switch + close
 depends_on: [step-1]
-status: ready
+status: done
+assignee:
+claimed_at:
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-2.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-2.md
@@ -1,0 +1,100 @@
+---
+id: step-2
+name: Multi-file open + switch + close
+depends_on: [step-1]
+status: ready
+---
+
+<!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
+working, then transitions `status` to `done` (success) or back to `ready` (retry-able failure). -->
+
+# step-2: Multi-file open + switch + close
+
+## Overview
+
+Make tabs actually work as a multi-file UX. After step-1, the strip exists but only one tab can live at a time. This step lets the user open multiple files (CLI args `file-review a.md b.md`, `cmd+O` appends instead of replacing, and drag-and-drop appends), click any tab to switch, close any tab via its `×` or via `cmd+W`, and jump to the Nth tab via `cmd+1..9`. Editor + preview swap their displayed content based on the active tab. **Critical correctness bar**: switching tabs must NOT lose dirty edits — the outgoing tab's editor doc gets snapshotted to `tab.doc` before swap. Cursor position, scroll offset, and per-tab comments cache are deferred to step-3; this step handles the doc-content snapshot only.
+
+## Changes Required:
+
+#### 1. Multi-file open
+
+**File**: `file-review/src/main.ts`
+**Changes**:
+- Refactor `loadFile(path, { mode: 'replace' | 'append' } = { mode: 'append' })`:
+  - `append` (default): if a tab already has this path, `setActive` to it; else `tabManager.add({ path, ... })` and `setActive(newId)`.
+  - `replace`: existing single-tab behavior (used internally for the seed-on-launch case if no args, or for explicit "replace current tab" UX — wire to a context-menu "replace in current tab" later, not in this step).
+- Update `showFilePickerAndLoad` to call `loadFile(path)` (default `append`).
+- Drag-and-drop handler: in Tauri, use `getCurrentWebview().onDragDropEvent((event) => { ... })` from `@tauri-apps/api/webview` (Tauri 2's API — replaces v1's `tauri://file-drop` event). For `dev:web` fallback, register HTML5 `dragover` + `drop` listeners on `document.body`. For each path, call `loadFile(path)` (append). Verify the exact import path against the installed `@tauri-apps/api` v2.10 docs at implementation time.
+
+**File**: `file-review/src-tauri/src/lib.rs`
+**Changes**:
+- The CLI-args entry point (where stdin / argv files are passed to JS): emit a `tauri://files-from-args` event with **all** paths. JS listens and calls `loadFile` for each.
+- `set_current_file` command: stays as-is (still tracks "active file" — we keep one Rust-side active for the close-export flow until step-3 promotes it to multi-file).
+
+#### 2. Switching tabs (with doc snapshot)
+
+**File**: `file-review/src/tabs.ts`
+**Changes**:
+- Extend `Tab` interface: add `doc: string` (the in-memory editor content with comment markers inlined). Initialize from disk on `add`.
+
+**File**: `file-review/src/main.ts`
+**Changes**:
+- Add `snapshotActiveDoc()`: `const tab = tabManager.getActive(); if (!tab) return; tabManager.update(tab.id, { doc: getEditorContent() });` — captures the dirty/clean editor state into the tab.
+- Add `activateTab(id)`: pulls target tab; calls `setEditorContent(target.doc)` (NOT `API.readFile` — the in-memory doc is the source of truth once a tab exists); replays `parseAndStripComments(target.doc)` into `tab.comments`; calls `renderCommentState()` and `updateViewMode()`.
+- Hook into `tabManager.subscribe`: on active-change `{ from, to }` → call `snapshotActiveDoc()` (against `from`) **before** activating `to`. The subscriber API in step-1's `tabs.ts` must expose both old and new IDs for this to work — confirm/adjust there.
+- `API.setCurrentFile(target.path)` so the Rust save flow points at the right file.
+- Cursor/scroll preservation, per-tab comments cache as a separate field, and dirty-tracking refinements are step-3's job. This step's snapshot is just `doc` so no edits are lost on switch.
+
+#### 3. Closing tabs
+
+**File**: `file-review/src/main.ts` and `file-review/src/tabs-view.ts`
+**Changes**:
+- `closeTab(id)`: if the tab is dirty, prompt via `confirm()` "Discard unsaved changes in `<basename>`?". On confirm or if clean, `tabManager.remove(id)`. If `id` was active, `setActive(nextTab?.id ?? null)`. If 0 tabs remain, show empty state (existing flow).
+- Tabs-view: any tab's `×` button works — not just the active one. Middle-click on the tab body also closes (matches browser convention).
+
+#### 4. Keyboard shortcuts: cmd+W, cmd+1..9, cmd+T rebind
+
+**File**: `file-review/src/shortcuts.ts`
+**Changes**:
+- Add `Cmd+W` handler: `closeTab(tabManager.activeId)`. Place this **before** the `editingText` early-return at line 151 (it must work even with editor focus).
+- Add `Cmd+1..9` handler: `tabManager.setActive(tabManager.tabs[n - 1]?.id)`. Also placed before the `editingText` guard.
+- Move existing `Cmd+T` (theme toggle) to `Cmd+Shift+T`. Free `Cmd+T` for "new tab" (opens file picker, append mode).
+- Update the in-app keyboard help overlay (toolbar `?` button → existing help modal) to reflect new shortcuts.
+
+**File**: `file-review/src-tauri/src/lib.rs`
+**Changes**:
+- Tauri menu accelerator for `Cmd+W`: emit a `menu:close-tab` event the JS listens to (in case the OS-level Cmd+W still fires before the JS handler).
+
+#### 5. Open-multiple via dialog + drag-drop
+
+**File**: `file-review/src/file-picker.ts`
+**Changes**:
+- `showFilePicker()` already uses Tauri's `open` dialog — pass `{ multiple: true }` and return `string[]`.
+
+**File**: `file-review/src/main.ts`
+**Changes**:
+- `showFilePickerAndLoad`: handle `string[]` — for each path, `loadFile(path)`.
+- Drag-drop: register Tauri's `tauri://drag-drop` event on the window (or fall back to HTML5 `drop` for `dev:web`); for each path, `loadFile(path)`.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Typecheck passes: `cd file-review && bun run check`
+- [ ] Build passes: `cd file-review && bun run build`
+- [ ] No new `console.error` or unhandled-rejection in dev console (sub-agent confirms)
+
+#### Automated QA:
+- [ ] Sub-agent launches `bun run dev:web file-review/test-files/sample.md file-review/test-files/sample-2.md` (creates a 2nd test file if missing), confirms two tabs visible, second active
+- [ ] Sub-agent clicks the first tab, confirms editor swaps to its content; clicks the second, confirms swap-back
+- [ ] **Dirty-edit preservation regression test**: sub-agent edits tab A (types "ZZZZ" at line 1), switches to tab B, switches back to A — confirms "ZZZZ" is still in the editor (the doc-snapshot path). This is the critical correctness bar for this step.
+- [ ] Sub-agent presses `Cmd+1`, confirms first tab activates; `Cmd+2`, confirms second activates
+- [ ] Sub-agent edits the second tab one char (confirm dirty dot appears), presses `Cmd+W`, confirms a confirmation prompt fires; on dismiss the tab stays; on accept the tab closes
+- [ ] Sub-agent presses `Cmd+W` on a clean first tab, confirms it closes silently and editor returns to empty state
+- [ ] Sub-agent presses `Cmd+T`, confirms a file picker opens (not a theme toggle); `Cmd+Shift+T` toggles theme
+- [ ] Sub-agent triggers an HTML5 drop event on the window with two file paths in `dev:web`, confirms two new tabs appear
+
+#### Manual Verification:
+- [ ] CLI args path: `bun run dev -- file-review/test-files/a.md file-review/test-files/b.md` opens both as tabs (Tauri-only — covered by manual run since CLI handoff differs from `dev:web`)
+- [ ] Drag-drop in the actual Tauri window (not browser) appends tabs
+
+**Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. After verification passes, commit with `[step-2] Multi-file open + switch + close + keyboard shortcuts`.

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-3.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-3.md
@@ -2,7 +2,9 @@
 id: step-3
 name: Per-tab state preservation + multi-file export
 depends_on: [step-2]
-status: ready
+status: done
+assignee:
+claimed_at:
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-3.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-3.md
@@ -1,0 +1,102 @@
+---
+id: step-3
+name: Per-tab state preservation + multi-file export
+depends_on: [step-2]
+status: ready
+---
+
+<!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
+working, then transitions `status` to `done` (success) or back to `ready` (retry-able failure). -->
+
+# step-3: Per-tab state preservation + multi-file export
+
+## Overview
+
+Make tab-switching feel instant and lossless beyond just doc content. Step-2 already snapshots `tab.doc` on switch (preventing dirty-edit loss). This step layers on **cursor position**, **scroll offset**, **per-tab parsed comments cache**, **per-tab dirty flag** with its own `lastSavedSnapshot`, and a per-tab `pendingPreviewComment`. Also: extend the close-window comment-export flow (`src-tauri/src/lib.rs` `WindowEvent::CloseRequested`) so it dumps comments for **every** open tab (not just the active file).
+
+## Changes Required:
+
+#### 1. Tab caches cursor + scroll (doc already cached in step-2)
+
+**File**: `file-review/src/tabs.ts`
+**Changes**:
+- Extend `Tab` interface (step-2 already added `doc`): add `cursor: { from: number; to: number }`, `scrollTop: number`.
+- `add()` initializes them as `{ from: 0, to: 0 }` and `0`.
+
+**File**: `file-review/src/main.ts`
+**Changes**:
+- Promote step-2's `snapshotActiveDoc()` into a fuller `snapshotActiveTab()`: also reads `getEditorState()` (introduced in step-1) to capture `cursor` + `scrollTop` into the active tab.
+- `activateTab(id)`: extend step-2's version — after `setEditorContent(target.doc)`, also call `setEditorState({ cursor: target.cursor, scrollTop: target.scrollTop })`. Use `target.comments` directly (don't re-parse) once per-tab comment cache is wired up.
+- The subscriber registered in step-2 (`{ from, to }` callback) keeps the same shape — just snapshots more fields now.
+- The `onDocumentChange` listener in `editor.ts` updates `readActive().doc` (already happening) and `readActive().hasUnsavedChanges` / dirty-snapshot fields per tab.
+
+#### 2. Read-from-disk only happens once per tab (on open)
+
+**File**: `file-review/src/main.ts`
+**Changes**:
+- `loadFile(path)` (append branch): `API.readFile(path)` → `parseAndStripComments` → `tabManager.add({ path, doc: editorContent, comments, hasUnsavedChanges: false, lastSavedSnapshot: serialize(...), ... })`.
+- `loadFile(path)` (replace branch): same but mutate the existing tab.
+- `activateTab` no longer reads disk.
+
+#### 3. Per-tab dirty-tracking
+
+**File**: `file-review/src/main.ts`, `file-review/src/editor.ts`
+**Changes**:
+- `syncUnsavedChangesState()` operates on the active tab (via `readActive() / writeActive`). Already covered by step-1's refactor — verify here.
+- Tab strip dirty indicator: subscribe to `tabManager` for `update` events and re-render (or just toggle `data-dirty` on the affected `.tab` button).
+- `saveFile()`: writes the active tab's path; updates the active tab's `lastSavedSnapshot` and `hasUnsavedChanges = false`. No change of behavior for single-tab; just per-tab now.
+
+#### 4. Multi-file comment export on close
+
+**File**: `file-review/src-tauri/src/lib.rs`
+**Changes**:
+- New Tauri command `submit_tab_states(payload: Vec<TabState>)` where `TabState = { path: String, content: String }` (content = the in-memory editor doc with comment markers inlined — i.e., the result of `serializeComments(tab.doc, tab.comments)` from `comments.ts`).
+- `AppState`: add `Mutex<Vec<TabState>>` `open_tabs`. Keep `current_file: Mutex<Option<PathBuf>>` as "active tab" for the menu/save flow.
+- `WindowEvent::CloseRequested` (lines 110-176): instead of reading active file from disk, iterate `open_tabs`. For each, call `parse_comments_for_output(content)` (the existing string-based parser — no disk read needed since we already have the in-memory string). Dump grouped by file path:
+  ```
+  ## file-review/test-files/a.md
+
+  - <comment 1>
+  - <comment 2>
+
+  ## file-review/test-files/b.md
+
+  - <comment 3>
+  ```
+- When `open_tabs` has exactly one entry, preserve the **existing single-file output format** (no `## <path>` heading) for backward compatibility with shell consumers. Only multi-tab sessions get the heading-grouped format.
+- `format_comments_readable` and `format_comments_json` get a multi-file wrapper that loops; both formats keep their single-file shape when only one tab is open.
+- `state.silent` still suppresses output — unchanged.
+
+**File**: `file-review/src/main.ts`, `file-review/src/api.ts`
+**Changes**:
+- New helper `pushTabStatesToRust()`: builds payload as `tabManager.tabs.map(t => ({ path: t.path, content: serializeComments(t.doc, t.comments) }))` — using the existing `serializeComments` import from `comments.ts`. Call **only on close**, NOT on every save/switch:
+  - Register a `beforeunload` handler that calls a synchronous-ish path (`API.submitTabStates(payload)` — Tauri commands return a promise; the handler awaits in the `dev:web` flow and uses Tauri's `WindowEvent::CloseRequested` interception in the desktop flow).
+  - In the desktop flow, the Rust close handler must already have `open_tabs` populated. To avoid a race: also call `pushTabStatesToRust()` once when a tab is **closed** by the user (so a partial-session stdout reflects what was open at that moment). Saves do NOT push state — they only update Rust's `current_file`.
+- This minimizes serialization on hot paths; the worst case is one push per tab-close + one final push on window-close.
+
+#### 5. Process-comments round-trip
+
+**File**: `file-review/scripts/` and any docs referencing single-file `process-comments`
+**Changes**:
+- The `/file-review:process-comments` skill reads from disk per-file, so multi-tab doesn't break it inherently — verify by closing a multi-tab session, parsing the stdout, confirming the per-file headings appear and the skill picks the right one when run with a path arg.
+- Document the multi-file output format in `file-review/README.md` if it differs from today's.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Typecheck passes: `cd file-review && bun run check`
+- [ ] Build passes: `cd file-review && bun run build`
+- [ ] Rust tests/cargo check passes: `cd file-review/src-tauri && cargo check`
+- [ ] No `disk read on activate` in `activateTab` (grep `API.readFile` and confirm only `loadFile` calls it)
+
+#### Automated QA:
+- [ ] Sub-agent opens two files; in tab A, scrolls to line 100 + places cursor at line 50; switches to tab B, scrolls to line 30; switches back to A — confirms cursor at line 50, scroll at line 100
+- [ ] Sub-agent edits tab A (dirty), switches to tab B, edits B (dirty), confirms both `data-dirty="true"`; saves A (`Cmd+S`), confirms only A's dirty clears
+- [ ] Sub-agent closes the window with both tabs dirty; captures stdout; asserts the output has `## <path-A>` and `## <path-B>` sections each with the unsaved comments
+- [ ] Sub-agent runs `/file-review:process-comments file-review/test-files/a.md` after close, confirms it ingests A's comments correctly
+
+#### Manual Verification:
+- [ ] Switching tabs feels instantaneous (no flicker, no disk-read latency)
+- [ ] Closing a dirty tab via X, Cmd+W, or window-close all surface the same confirm prompt and behave consistently
+
+**Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. After verification passes, commit with `[step-3] Per-tab state preservation + multi-file comment export`.

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-4.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-4.md
@@ -2,7 +2,9 @@
 id: step-4
 name: Mermaid rendering in preview
 depends_on: []
-status: ready
+status: done
+assignee:
+claimed_at:
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -107,10 +109,10 @@ Render ` ```mermaid ` fenced code blocks as inline SVG diagrams in the markdown 
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Typecheck passes: `cd file-review && bun run check`
-- [ ] Build passes: `cd file-review && bun run build`
-- [ ] Bundle inspection: `ls -la file-review/dist/assets/ | grep mermaid` shows mermaid is split into its own chunk (dynamic-imported, not inlined into main bundle)
-- [ ] Tauri config validates: `cd file-review/src-tauri && cargo build` (catches CSP issues)
+- [x] Typecheck passes: `cd file-review && bun run check`
+- [x] Build passes: `cd file-review && bun run build`
+- [x] Bundle inspection: `ls -la file-review/dist/assets/ | grep mermaid` shows mermaid is split into its own chunk (dynamic-imported, not inlined into main bundle)
+- [x] Tauri config validates: `cd file-review/src-tauri && cargo build` (catches CSP issues)
 
 #### Automated QA:
 - [ ] Sub-agent launches `bun run dev:web file-review/test-files/with-mermaid.md`, screenshots the preview, confirms: SVG diagrams visible (not raw mermaid source), TypeScript fence still hljs-styled, broken mermaid block shows the `mermaid-error` div with a parseable error message

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-4.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-4.md
@@ -1,0 +1,124 @@
+---
+id: step-4
+name: Mermaid rendering in preview
+depends_on: []
+status: ready
+---
+
+<!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
+working, then transitions `status` to `done` (success) or back to `ready` (retry-able failure). -->
+
+# step-4: Mermaid rendering in preview
+
+## Overview
+
+Render ` ```mermaid ` fenced code blocks as inline SVG diagrams in the markdown preview pane. Theme-aware (re-renders on light/dark toggle), idempotent across keystroke updates (no double-render), and gracefully shows an inline error message when the diagram syntax is invalid. Existing highlight.js fences for other languages keep working — mermaid blocks must be transformed **before** hljs runs, since hljs would otherwise wrap mermaid source in `<span>` tokens and break parsing. Independent of the tabs work — only touches `markdown-preview.ts`, a new `mermaid.ts` module, `package.json`, and the Tauri CSP.
+
+## Changes Required:
+
+#### 1. Add mermaid dependency + dynamic import (with failure guard)
+
+**File**: `file-review/package.json`
+**Changes**:
+- Add `"mermaid": "^11"` to `dependencies`.
+- Run `bun install`.
+
+**File**: `file-review/src/mermaid.ts` (new)
+**Changes**:
+- Module-private `mermaidPromise: Promise<typeof import('mermaid').default> | null = null` and `mermaidLoadFailed = false`.
+- Export `getMermaid()`: if `mermaidLoadFailed`, throw a sentinel `MermaidLoadError`. Else lazy `mermaidPromise ??= import('mermaid').then(m => { m.default.initialize({ startOnLoad: false, securityLevel: 'strict', theme: getCurrentTheme() === 'dark' ? 'dark' : 'default' }); return m.default; }).catch(err => { mermaidLoadFailed = true; throw new MermaidLoadError(err); })`.
+- Export `renderMermaidBlocks(container: HTMLElement, signal?: AbortSignal): Promise<void>`: queries `container.querySelectorAll<HTMLElement>('.mermaid:not([data-processed="true"])')`. If zero, return immediately. Else:
+  ```ts
+  try {
+    const mermaid = await getMermaid();
+    if (signal?.aborted) return;
+    await mermaid.run({ nodes: Array.from(nodes), suppressErrors: true });
+  } catch (err) {
+    if (err instanceof MermaidLoadError) {
+      // Inline-render a single banner replacing all unprocessed mermaid blocks
+      for (const node of nodes) {
+        node.outerHTML = `<div class="mermaid-error">Diagram rendering unavailable (${escapeHtml(String(err.cause))})</div>`;
+      }
+    } else {
+      console.error('mermaid.run failed', err);
+    }
+  }
+  ```
+- Export `resetMermaidProcessed(container: HTMLElement)`: for theme switches — strips `data-processed`, restores `innerHTML` from `data-src` (decode). Caller follows up with `renderMermaidBlocks(container)` to re-render.
+- After the import resolves, also reset `mermaid.initialize` if the theme changed since first load: keep last-applied theme in a module var; if it differs, call `initialize` again before `run`.
+
+#### 2. marked walkTokens hook for mermaid blocks
+
+**File**: `file-review/src/markdown-preview.ts`
+**Changes**:
+- Register a `walkTokens` hook **once at module scope** (NOT inside a render call — `marked.use()` inside a render recurses):
+  ```ts
+  marked.use({
+    walkTokens(token) {
+      if (token.type === 'code' && token.lang === 'mermaid') {
+        // Mutate into an html token so the default code renderer is bypassed entirely.
+        const t = token as Tokens.Code & { type: string; raw: string; pre?: boolean; text?: string };
+        t.type = 'html';
+        t.pre = false;
+        t.text = `<pre class="mermaid" data-src="${encodeURIComponent(token.text)}">${escapeHtml(token.text)}</pre>`;
+      }
+    },
+  });
+  ```
+  This approach is preferred over a `extensions[]` entry because it doesn't require a custom tokenizer and runs after the default lexer has already classified the fence — fewer ways to drift from `marked`'s code-fence parsing rules.
+- **Fire-and-forget pattern with cancellation** in `updatePreview()` to avoid blocking keystroke renders:
+  ```ts
+  let activeMermaidController: AbortController | null = null;
+
+  function updatePreview(content, comments) {
+    // ... existing renderMarkdown / innerHTML write ...
+    activeMermaidController?.abort(); // cancel any in-flight render
+    activeMermaidController = new AbortController();
+    void renderMermaidBlocks(previewContainer, activeMermaidController.signal);
+    highlightCodeBlocks(); // unchanged, runs synchronously
+  }
+  ```
+  `updatePreview` stays **synchronous**. Mermaid renders out-of-band; the latest call wins via `AbortSignal`. `highlightCodeBlocks` runs as before — since walkTokens already converted mermaid fences into `html` tokens, there's no longer a `<pre><code class="language-mermaid">` for hljs to mangle.
+
+#### 3. Theme switching re-renders
+
+**File**: `file-review/src/theme.ts` and `file-review/src/markdown-preview.ts`
+**Changes**:
+- After theme toggle (`updateTheme`), call `resetMermaidProcessed(previewContainer)` then `renderMermaidBlocks(previewContainer)`.
+- Add a small `mermaid-error` CSS class for the error UI: red border, monospace, displays the source.
+
+#### 4. CSS + CSP
+
+**File**: `file-review/src/styles.css`
+**Changes**:
+- `.mermaid` container: centered, max-width parent, theme-aware background.
+- `.mermaid-error`: distinct error styling.
+
+**File**: `file-review/src-tauri/tauri.conf.json`
+**Changes**:
+- CSP: ensure `style-src 'self' 'unsafe-inline'` (mermaid injects `<style>` tags). If a `csp` entry exists, update; else add.
+
+#### 5. Test fixture
+
+**File**: `file-review/test-files/with-mermaid.md` (new)
+**Changes**:
+- Include several mermaid block types (`graph TD`, `sequenceDiagram`, `classDiagram`), one valid + one intentionally broken to verify error UI, plus normal code fences (TypeScript, Bash) so we confirm hljs still handles them.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Typecheck passes: `cd file-review && bun run check`
+- [ ] Build passes: `cd file-review && bun run build`
+- [ ] Bundle inspection: `ls -la file-review/dist/assets/ | grep mermaid` shows mermaid is split into its own chunk (dynamic-imported, not inlined into main bundle)
+- [ ] Tauri config validates: `cd file-review/src-tauri && cargo build` (catches CSP issues)
+
+#### Automated QA:
+- [ ] Sub-agent launches `bun run dev:web file-review/test-files/with-mermaid.md`, screenshots the preview, confirms: SVG diagrams visible (not raw mermaid source), TypeScript fence still hljs-styled, broken mermaid block shows the `mermaid-error` div with a parseable error message
+- [ ] Sub-agent edits a mermaid block (one keystroke), confirms preview re-renders the diagram without flicker AND without two stacked SVGs
+- [ ] Sub-agent toggles theme (Cmd+Shift+T), confirms diagrams re-render with the new theme colors (compare two screenshots)
+- [ ] Sub-agent confirms console has no errors related to mermaid
+
+#### Manual Verification:
+- [ ] On a Tauri build (not just dev:web), CSP doesn't block mermaid styles — open `bun run dev`, view a mermaid file, confirm SVGs render
+
+**Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. After verification passes, commit with `[step-4] Mermaid diagram rendering in preview`.

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-5.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-5.md
@@ -1,0 +1,68 @@
+---
+id: step-5
+name: Integration + cross-cutting QA
+depends_on: [step-3, step-4]
+status: ready
+---
+
+<!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
+working, then transitions `status` to `done` (success) or back to `ready` (retry-able failure). -->
+
+# step-5: Integration + cross-cutting QA
+
+## Overview
+
+Verify that tabs (steps 1–3) and mermaid (step 4) compose cleanly. Open multiple files in tabs where at least two contain mermaid blocks, switch between them, edit, save, close — confirm preview state is per-tab, no diagram leaks across tabs, no double-render after switch+return, and the multi-file comment-export flow still produces correct output. Also: bump version + run a Tauri release build to catch packaging issues that don't surface in `dev:web`.
+
+## Changes Required:
+
+#### 1. Cross-feature wiring sanity
+
+**File**: `file-review/src/main.ts`
+**Changes**:
+- Confirm `activateTab(id)` calls `updatePreview` (which now awaits mermaid render). Make sure switching to a tab whose markdown contains mermaid blocks renders correctly without manual scroll/refresh.
+- Confirm theme toggle re-renders mermaid in the **active** tab's preview. (Background tabs' diagrams will re-render lazily on next activation — document this.)
+
+#### 2. Help overlay and README updates
+
+**File**: `file-review/src/main.ts` (help modal HTML) + `file-review/README.md`
+**Changes**:
+- Update the keyboard shortcut help section: list `Cmd+T` (new tab), `Cmd+W` (close tab), `Cmd+1..9` (switch tab), `Cmd+Shift+T` (toggle theme — moved).
+- Add a "Tabs" section to README describing CLI multi-file usage: `file-review a.md b.md c.md`.
+- Add a "Mermaid" section to README listing supported diagram types and noting `securityLevel: 'strict'` (no scripted features).
+
+#### 3. Version bump + release prep
+
+**File**: `file-review/package.json`, `file-review/src-tauri/tauri.conf.json`, `file-review/src-tauri/Cargo.toml`
+**Changes**:
+- Bump from `1.7.3` to `1.8.0` (minor — two new features) in all three files. Per project CLAUDE.md, these must stay in sync.
+- After `bun run install:web` runs, `file-review/src-tauri/Cargo.lock` will be updated by the build — commit and push it as a separate commit per the project release process.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Typecheck passes: `cd file-review && bun run check`
+- [ ] Build passes: `cd file-review && bun run build`
+- [ ] Cargo build passes: `cd file-review/src-tauri && cargo build --release`
+- [ ] All three version files match: `grep -E '^"?version"?\s*[=:]' file-review/package.json file-review/src-tauri/tauri.conf.json file-review/src-tauri/Cargo.toml` shows `1.8.0` everywhere
+- [ ] No leftover `console.log` / `dbg!` calls in changed files
+
+#### Automated QA:
+- [ ] Sub-agent launches `bun run dev:web file-review/test-files/with-mermaid.md file-review/test-files/sample.md`, confirms two tabs, both render correctly, mermaid SVGs only in the right tab
+- [ ] Sub-agent presses `Cmd+1` then `Cmd+2` ten times rapidly, confirms no console errors and no DOM accumulation (count `.mermaid[data-processed="true"]` stays bounded)
+- [ ] Sub-agent edits the mermaid file (one keystroke per second × 10), confirms diagrams update without stacking
+- [ ] Sub-agent toggles theme on the mermaid tab, switches to the non-mermaid tab, switches back, confirms diagrams have the new theme (lazy re-render fires on activation)
+- [ ] Sub-agent dirties both tabs, closes window, captures stdout, asserts both files appear in the multi-file comment export with their respective comments
+- [ ] Sub-agent runs `/file-review:process-comments file-review/test-files/sample.md` against the captured output, confirms it ingests comments correctly
+
+#### Manual Verification:
+- [ ] Run a real Tauri release build via `bun run install:web`; open the installed binary on `with-mermaid.md` + `sample.md` simultaneously; verify mermaid renders, tabs work, save works, comment-export-on-close works
+- [ ] Visual judgment: tab strip, mermaid styling, error UI all look polished in both themes
+
+### QA Spec (optional):
+
+Cross-cutting evidence-heavy verification with screenshots, recordings, and the multi-file export stdout transcript belongs in a separate QA doc.
+
+**QA Doc**: `thoughts/taras/qa/2026-04-28-file-review-tabs-mermaid.md` (generate via `desplega:qa`; scenarios live in the doc, not here).
+
+**Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. After verification passes, commit with `[step-5] Integration QA + version bump to 1.8.0`.

--- a/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-5.md
+++ b/thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/step-5.md
@@ -2,7 +2,9 @@
 id: step-5
 name: Integration + cross-cutting QA
 depends_on: [step-3, step-4]
-status: ready
+status: done
+assignee:
+claimed_at:
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while


### PR DESCRIPTION
## Summary
- **Multi-file tabs** — open multiple files in one window, switch via click/`Cmd+1..9`, close via X/`Cmd+W`, new tab via `Cmd+T`. Per-tab dirty/cursor/scroll preserved across switches. Theme toggle moved to `Cmd+Shift+T`.
- **Mermaid diagram rendering** in markdown preview — `\`\`\`mermaid` fences render as inline SVG, theme-aware, lazy-loaded (~2MB chunked into per-diagram-type bundles), graceful error UI for invalid syntax.
- **Copy button on code blocks** — hover any rendered code fence in preview to reveal a Copy button (out-of-plan but small + adjacent).
- **Multi-file comment export** — closing the window now dumps comments from every open tab grouped under `## <path>` headers; single-tab sessions keep the existing flat format for shell-consumer compat.
- **CLI args**: `file-review a.md b.md c.md` opens all three; relative paths resolve correctly even under `tauri dev`.
- Version bumped 1.7.3 → 1.8.0.

Implemented per the DAG plan in `thoughts/taras/plans/2026-04-28-file-review-tabs-mermaid/` via `/desplega:v-implement`.

## Test plan
- [ ] `bun run dev -- ./test-files/with-mermaid.md ./test-files/frontmatter-preview-regression.md` — both tabs open, mermaid renders, switching preserves cursor/scroll/dirty state per tab
- [ ] Add comments in both tabs, close window — both files' comments appear in stdout under `## <path>` headers
- [ ] `Cmd+T`, `Cmd+W`, `Cmd+1..9`, `Cmd+Shift+T` all work as documented in the help modal (`?` button or `Cmd+/`)
- [ ] Drag two files into the window — both append as tabs
- [ ] Toggle theme on a mermaid file — diagrams re-render with new theme colors
- [ ] Copy button: hover a code block → button appears top-right → click copies the source
- [ ] Vim mode, save (`Cmd+S`), comment markers, file-review:process-comments round-trip all unchanged for single-file sessions