### PR TITLE
fix(file-review): close-guard regression + closed-files session + cmd+n/p

### DIFF
--- a/file-review/index.html
+++ b/file-review/index.html
@@ -41,7 +41,7 @@
     <div id="tab-strip-row" class="tab-strip-row">
       <div id="tab-strip" class="tab-strip" role="tablist"></div>
       <button id="closed-files-btn" class="closed-files-btn" type="button" title="Closed files in this review session" aria-label="Closed files" hidden>
-        <span class="icon">&#x1F4DA;</span>
+        <span class="icon">&#9776;</span>
         <span id="closed-files-count" class="closed-files-count">0</span>
       </button>
     </div>

--- a/file-review/index.html
+++ b/file-review/index.html
@@ -38,7 +38,14 @@
         </button>
       </div>
     </div>
-    <div id="tab-strip" class="tab-strip" role="tablist"></div>
+    <div id="tab-strip-row" class="tab-strip-row">
+      <div id="tab-strip" class="tab-strip" role="tablist"></div>
+      <button id="closed-files-btn" class="closed-files-btn" type="button" title="Closed files in this review session" aria-label="Closed files" hidden>
+        <span class="icon">&#x1F4DA;</span>
+        <span id="closed-files-count" class="closed-files-count">0</span>
+      </button>
+    </div>
+    <div id="closed-files-popover" class="closed-files-popover" hidden></div>
     <div id="main-container">
       <div id="editor-container"></div>
       <div id="preview-wrapper" style="display: none; position: relative; flex: 7;">

--- a/file-review/src-tauri/capabilities/default.json
+++ b/file-review/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-destroy",
     "dialog:default",
     "fs:default"
   ]

--- a/file-review/src/main.ts
+++ b/file-review/src/main.ts
@@ -76,6 +76,124 @@ function readActive(): Tab | null {
 }
 
 /**
+ * Saved-and-closed tabs that should still appear in the final close-window
+ * comment-export summary. Discarded closes never land here. Each entry's
+ * `content` is the on-disk serialization at close time.
+ */
+interface ClosedFileEntry {
+  path: string;
+  content: string;
+}
+const closedFiles: ClosedFileEntry[] = [];
+const closedFilesSubscribers: Array<() => void> = [];
+function notifyClosedFilesChange() {
+  for (const fn of closedFilesSubscribers) fn();
+}
+function addClosedFile(entry: ClosedFileEntry) {
+  // De-dupe by path: if already remembered, replace with newer content.
+  const existing = closedFiles.findIndex((f) => f.path === entry.path);
+  if (existing >= 0) closedFiles[existing] = entry;
+  else closedFiles.push(entry);
+  notifyClosedFilesChange();
+}
+function removeClosedFile(path: string) {
+  const idx = closedFiles.findIndex((f) => f.path === path);
+  if (idx >= 0) {
+    closedFiles.splice(idx, 1);
+    notifyClosedFilesChange();
+  }
+}
+
+function setupClosedFilesIndicator() {
+  const btn = document.getElementById("closed-files-btn") as HTMLButtonElement | null;
+  const count = document.getElementById("closed-files-count");
+  const popover = document.getElementById("closed-files-popover");
+  if (!btn || !count || !popover) return;
+
+  const renderIndicator = () => {
+    const n = closedFiles.length;
+    if (n === 0) {
+      btn.hidden = true;
+      popover.hidden = true;
+      return;
+    }
+    btn.hidden = false;
+    count.textContent = String(n);
+  };
+
+  const renderPopover = () => {
+    if (closedFiles.length === 0) {
+      popover.hidden = true;
+      return;
+    }
+    const items = closedFiles
+      .map((f) => {
+        const basename = f.path.split("/").pop() || f.path;
+        return `
+          <div class="closed-files-popover-item" data-path="${escapeHtml(f.path)}">
+            <span class="closed-files-popover-path" title="${escapeHtml(f.path)}">${escapeHtml(basename)}</span>
+            <button class="closed-files-popover-remove" type="button" aria-label="Remove from review session">×</button>
+          </div>`;
+      })
+      .join("");
+    popover.innerHTML = `
+      <div class="closed-files-popover-header">In this review session</div>
+      ${items}
+    `;
+    popover.querySelectorAll<HTMLButtonElement>(".closed-files-popover-remove").forEach((rm) => {
+      rm.addEventListener("click", (e) => {
+        e.stopPropagation();
+        const item = (e.currentTarget as HTMLElement).closest<HTMLElement>(
+          ".closed-files-popover-item"
+        );
+        const path = item?.dataset.path;
+        if (path) {
+          removeClosedFile(path);
+          void pushTabStatesToRust();
+        }
+      });
+    });
+  };
+
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (popover.hidden) {
+      renderPopover();
+      popover.hidden = false;
+    } else {
+      popover.hidden = true;
+    }
+  });
+  document.addEventListener("click", (e) => {
+    if (popover.hidden) return;
+    const target = e.target as Node;
+    if (popover.contains(target) || btn.contains(target)) return;
+    popover.hidden = true;
+  });
+
+  closedFilesSubscribers.push(() => {
+    renderIndicator();
+    if (!popover.hidden) renderPopover();
+  });
+  renderIndicator();
+}
+
+/**
+ * Cycle the active tab forward (+1) or backward (-1) with wrap-around.
+ * No-op if fewer than 2 tabs exist.
+ */
+function rotateActiveTab(direction: 1 | -1) {
+  if (tabManager.tabs.length < 2) return;
+  const activeIdx = tabManager.tabs.findIndex(
+    (t) => t.id === tabManager.activeId
+  );
+  if (activeIdx < 0) return;
+  const len = tabManager.tabs.length;
+  const nextIdx = (activeIdx + direction + len) % len;
+  tabManager.setActive(tabManager.tabs[nextIdx].id);
+}
+
+/**
  * Patch fields on the active tab. No-op if no tab is open.
  */
 function writeActive(patch: Partial<Tab>): void {
@@ -272,6 +390,8 @@ async function init() {
       const target = tabManager.tabs[n - 1];
       if (target) tabManager.setActive(target.id);
     },
+    nextTab: () => rotateActiveTab(1),
+    prevTab: () => rotateActiveTab(-1),
     zoomIn,
     zoomOut,
     undo: editorUndo,
@@ -364,6 +484,11 @@ async function init() {
   document
     .getElementById("open-file-btn")
     ?.addEventListener("click", showFilePickerAndLoad);
+
+  // Closed-files indicator: button + popover. Visible only when at least
+  // one tab has been closed-with-save during this session. Lets the user
+  // remove an entry (drops it from the final stdout summary).
+  setupClosedFilesIndicator();
 
   // Set up toolbar buttons
   document
@@ -1152,14 +1277,21 @@ async function pushTabStatesToRust(): Promise<void> {
   if (active) {
     tabManager.update(active.id, { doc: getEditorContent() });
   }
-  const states = tabManager.tabs
+  const openStates = tabManager.tabs
     .filter((t) => t.path !== null)
     .map((t) => ({
       path: t.path!,
       content: serializeComments(t.doc, t.comments),
     }));
+  // Append closed-but-remembered files so the final stdout summary
+  // includes them too. De-dupe paths in favour of the open tab (a path
+  // can't be both open and closed simultaneously, but defensive).
+  const openPaths = new Set(openStates.map((s) => s.path));
+  const closedStates = closedFiles
+    .filter((f) => !openPaths.has(f.path))
+    .map((f) => ({ path: f.path, content: f.content }));
   try {
-    await API.submitTabStates(states);
+    await API.submitTabStates([...openStates, ...closedStates]);
   } catch (error) {
     console.error("Failed to push tab states:", error);
   }
@@ -1271,10 +1403,12 @@ function handleCommentClick(comment: ReviewComment) {
 async function closeTab(id: string) {
   const tab = tabManager.tabs.find((t) => t.id === id);
   if (!tab) return;
+  let discarded = false;
   if (tab.hasUnsavedChanges) {
     const label = tab.path ? tab.path.split("/").pop() || tab.path : "this tab";
     const choice = await showCloseTabConfirmDialog(label);
     if (choice === "cancel") return;
+    if (choice === "discard") discarded = true;
     if (choice === "save") {
       try {
         // Snapshot active editor content into the tab if this is the active
@@ -1297,6 +1431,21 @@ async function closeTab(id: string) {
       }
     }
   }
+
+  // Remember non-discarded closes so the final window-close summary
+  // still lists their comments. The captured `content` is what's on
+  // disk after any pending save: the in-memory editor doc combined
+  // with the comment markers.
+  const fresh = tabManager.tabs.find((t) => t.id === id);
+  if (fresh && fresh.path && !discarded) {
+    const docToCapture =
+      tabManager.activeId === id ? getEditorContent() : fresh.doc;
+    addClosedFile({
+      path: fresh.path,
+      content: serializeComments(docToCapture, fresh.comments),
+    });
+  }
+
   tabManager.remove(id);
   void pushTabStatesToRust();
 

--- a/file-review/src/main.ts
+++ b/file-review/src/main.ts
@@ -591,8 +591,13 @@ function escapeHtml(text: string): string {
 
 type QuitChoice = "save" | "discard" | "cancel";
 
+// Module-scoped guard so re-entrant Cmd+Q presses don't stack modals.
+let activeQuitDialog: Promise<QuitChoice> | null = null;
+
 function showQuitConfirmDialog(): Promise<QuitChoice> {
-  return new Promise((resolve) => {
+  if (activeQuitDialog) return activeQuitDialog;
+
+  activeQuitDialog = new Promise<QuitChoice>((resolve) => {
     const modal = document.createElement("div");
     modal.className = "quit-confirm-modal";
     modal.innerHTML = `
@@ -604,9 +609,9 @@ function showQuitConfirmDialog(): Promise<QuitChoice> {
           <p>You have unsaved comments or edits. What would you like to do?</p>
         </div>
         <div class="quit-confirm-footer">
-          <button class="secondary-btn" data-action="cancel">Cancel</button>
-          <button class="secondary-btn" data-action="discard">Quit anyway</button>
-          <button class="primary-btn" data-action="save">Save and quit</button>
+          <button class="secondary-btn" data-action="cancel">Cancel <kbd>Esc</kbd></button>
+          <button class="secondary-btn" data-action="discard">Quit anyway <kbd>Q</kbd></button>
+          <button class="primary-btn" data-action="save">Save and quit <kbd>S</kbd></button>
         </div>
       </div>
     `;
@@ -617,13 +622,23 @@ function showQuitConfirmDialog(): Promise<QuitChoice> {
       settled = true;
       document.removeEventListener("keydown", onKeydown);
       modal.remove();
+      activeQuitDialog = null;
       resolve(choice);
     };
 
     const onKeydown = (e: KeyboardEvent) => {
+      // Don't intercept system Cmd+Q while the dialog is open — let
+      // it fall through so the second Cmd+Q acts as Quit Anyway.
+      if (e.metaKey || e.ctrlKey) return;
       if (e.key === "Escape") {
         e.preventDefault();
         finish("cancel");
+      } else if (e.key === "q" || e.key === "Q") {
+        e.preventDefault();
+        finish("discard");
+      } else if (e.key === "s" || e.key === "S") {
+        e.preventDefault();
+        finish("save");
       }
     };
 
@@ -641,6 +656,8 @@ function showQuitConfirmDialog(): Promise<QuitChoice> {
     document.body.appendChild(modal);
     modal.querySelector<HTMLButtonElement>(".primary-btn")?.focus();
   });
+
+  return activeQuitDialog;
 }
 
 /**
@@ -669,42 +686,43 @@ async function saveAllDirtyTabs(): Promise<void> {
 async function registerTauriCloseGuard() {
   const { getCurrentWindow } = await import("@tauri-apps/api/window");
   const tauriWindow = getCurrentWindow();
-  let allowClose = false;
+  // Re-entry guard: a second Cmd+Q while the dialog is open or a save is
+  // in progress would otherwise stack handlers (and modal backdrops).
+  let resolving = false;
 
   await tauriWindow.onCloseRequested(async (event) => {
     const anyDirty = tabManager.tabs.some((t) => t.hasUnsavedChanges);
-    if (allowClose || !anyDirty) {
+    if (!anyDirty) {
       return;
     }
 
     event.preventDefault();
+    if (resolving) return;
+    resolving = true;
 
-    if (appConfig.save_on_quit) {
-      try {
+    try {
+      if (appConfig.save_on_quit) {
         await saveAllDirtyTabs();
-      } catch (error) {
-        console.error("Failed to save on quit:", error);
+        await tauriWindow.destroy();
         return;
       }
-      allowClose = true;
-      await tauriWindow.close();
-      return;
-    }
 
-    const choice = await showQuitConfirmDialog();
-    if (choice === "cancel") {
-      return;
-    }
-    if (choice === "save") {
-      try {
-        await saveAllDirtyTabs();
-      } catch (error) {
-        console.error("Failed to save before quit:", error);
+      const choice = await showQuitConfirmDialog();
+      if (choice === "cancel") {
         return;
       }
+      if (choice === "save") {
+        await saveAllDirtyTabs();
+      }
+      // Use destroy() instead of close() because we're inside the
+      // onCloseRequested handler; close() would re-enter the handler
+      // and (in some Tauri 2 webview builds) silently no-op.
+      await tauriWindow.destroy();
+    } catch (error) {
+      console.error("Failed to quit:", error);
+    } finally {
+      resolving = false;
     }
-    allowClose = true;
-    await tauriWindow.close();
   });
 }
 

--- a/file-review/src/main.ts
+++ b/file-review/src/main.ts
@@ -591,27 +591,37 @@ function escapeHtml(text: string): string {
 
 type QuitChoice = "save" | "discard" | "cancel";
 
-// Module-scoped guard so re-entrant Cmd+Q presses don't stack modals.
-let activeQuitDialog: Promise<QuitChoice> | null = null;
+interface UnsavedDialogOpts {
+  title: string;
+  body: string;
+  saveLabel: string;
+  discardLabel: string;
+  /** Single-letter (lowercase) shortcut key for the discard action. */
+  discardKey: string;
+}
 
-function showQuitConfirmDialog(): Promise<QuitChoice> {
-  if (activeQuitDialog) return activeQuitDialog;
+// Module-scoped guard so re-entrant triggers (Cmd+Q spam, Cmd+W spam)
+// don't stack dialog backdrops.
+let activeUnsavedDialog: Promise<QuitChoice> | null = null;
 
-  activeQuitDialog = new Promise<QuitChoice>((resolve) => {
+function showUnsavedChangesDialog(opts: UnsavedDialogOpts): Promise<QuitChoice> {
+  if (activeUnsavedDialog) return activeUnsavedDialog;
+
+  activeUnsavedDialog = new Promise<QuitChoice>((resolve) => {
     const modal = document.createElement("div");
     modal.className = "quit-confirm-modal";
     modal.innerHTML = `
       <div class="quit-confirm-content">
         <div class="quit-confirm-header">
-          <h3>Unsaved review progress</h3>
+          <h3>${escapeHtml(opts.title)}</h3>
         </div>
         <div class="quit-confirm-body">
-          <p>You have unsaved comments or edits. What would you like to do?</p>
+          <p>${escapeHtml(opts.body)}</p>
         </div>
         <div class="quit-confirm-footer">
           <button class="secondary-btn" data-action="cancel">Cancel <kbd>Esc</kbd></button>
-          <button class="secondary-btn" data-action="discard">Quit anyway <kbd>Q</kbd></button>
-          <button class="primary-btn" data-action="save">Save and quit <kbd>S</kbd></button>
+          <button class="secondary-btn" data-action="discard">${escapeHtml(opts.discardLabel)} <kbd>${opts.discardKey.toUpperCase()}</kbd></button>
+          <button class="primary-btn" data-action="save">${escapeHtml(opts.saveLabel)} <kbd>S</kbd></button>
         </div>
       </div>
     `;
@@ -622,18 +632,18 @@ function showQuitConfirmDialog(): Promise<QuitChoice> {
       settled = true;
       document.removeEventListener("keydown", onKeydown);
       modal.remove();
-      activeQuitDialog = null;
+      activeUnsavedDialog = null;
       resolve(choice);
     };
 
     const onKeydown = (e: KeyboardEvent) => {
-      // Don't intercept system Cmd+Q while the dialog is open — let
-      // it fall through so the second Cmd+Q acts as Quit Anyway.
+      // Don't intercept system Cmd+Q / Cmd+W while the dialog is open —
+      // a second press should fall through to the OS / menu accelerator.
       if (e.metaKey || e.ctrlKey) return;
       if (e.key === "Escape") {
         e.preventDefault();
         finish("cancel");
-      } else if (e.key === "q" || e.key === "Q") {
+      } else if (e.key.toLowerCase() === opts.discardKey) {
         e.preventDefault();
         finish("discard");
       } else if (e.key === "s" || e.key === "S") {
@@ -657,7 +667,27 @@ function showQuitConfirmDialog(): Promise<QuitChoice> {
     modal.querySelector<HTMLButtonElement>(".primary-btn")?.focus();
   });
 
-  return activeQuitDialog;
+  return activeUnsavedDialog;
+}
+
+function showQuitConfirmDialog(): Promise<QuitChoice> {
+  return showUnsavedChangesDialog({
+    title: "Unsaved review progress",
+    body: "You have unsaved comments or edits. What would you like to do?",
+    saveLabel: "Save and quit",
+    discardLabel: "Quit anyway",
+    discardKey: "q",
+  });
+}
+
+function showCloseTabConfirmDialog(label: string): Promise<QuitChoice> {
+  return showUnsavedChangesDialog({
+    title: `Close ${label}?`,
+    body: `${label} has unsaved comments or edits. What would you like to do?`,
+    saveLabel: "Save and close",
+    discardLabel: "Close anyway",
+    discardKey: "c",
+  });
 }
 
 /**
@@ -1234,15 +1264,37 @@ function handleCommentClick(comment: ReviewComment) {
 }
 
 /**
- * Close a tab by id. In step-1 only the active tab can be closed (single-tab
- * semantics); step-2 will allow closing any tab.
+ * Close a tab by id. If the tab has unsaved changes, prompts via the same
+ * 3-button dialog the close-window flow uses (Cancel / Close anyway /
+ * Save and close). Save persists the tab to disk before removing it.
  */
-function closeTab(id: string) {
+async function closeTab(id: string) {
   const tab = tabManager.tabs.find((t) => t.id === id);
   if (!tab) return;
   if (tab.hasUnsavedChanges) {
-    if (!window.confirm("You have unsaved changes. Close this tab and discard them?")) {
-      return;
+    const label = tab.path ? tab.path.split("/").pop() || tab.path : "this tab";
+    const choice = await showCloseTabConfirmDialog(label);
+    if (choice === "cancel") return;
+    if (choice === "save") {
+      try {
+        // Snapshot active editor content into the tab if this is the active
+        // tab (so we save the latest in-memory edits, not a stale doc).
+        if (tabManager.activeId === id) {
+          tabManager.update(id, { doc: getEditorContent() });
+        }
+        const fresh = tabManager.tabs.find((t) => t.id === id);
+        if (fresh && fresh.path) {
+          const serialized = serializeComments(fresh.doc, fresh.comments);
+          await API.writeFile(fresh.path, serialized);
+          tabManager.update(id, {
+            hasUnsavedChanges: false,
+            lastSavedSnapshot: serialized,
+          });
+        }
+      } catch (error) {
+        console.error("Failed to save tab before close:", error);
+        return;
+      }
     }
   }
   tabManager.remove(id);

--- a/file-review/src/main.ts
+++ b/file-review/src/main.ts
@@ -672,7 +672,16 @@ async function registerTauriCloseGuard() {
   let allowClose = false;
 
   await tauriWindow.onCloseRequested(async (event) => {
-    const anyDirty = tabManager.tabs.some((t) => t.hasUnsavedChanges);
+    const dirtyTabs = tabManager.tabs.filter((t) => t.hasUnsavedChanges);
+    const anyDirty = dirtyTabs.length > 0;
+    console.log("[close-guard]", {
+      allowClose,
+      anyDirty,
+      tabs: tabManager.tabs.map((t) => ({
+        path: t.path,
+        dirty: t.hasUnsavedChanges,
+      })),
+    });
     if (allowClose || !anyDirty) {
       return;
     }

--- a/file-review/src/main.ts
+++ b/file-review/src/main.ts
@@ -131,8 +131,8 @@ function setupClosedFilesIndicator() {
         const basename = f.path.split("/").pop() || f.path;
         return `
           <div class="closed-files-popover-item" data-path="${escapeHtml(f.path)}">
-            <span class="closed-files-popover-path" title="${escapeHtml(f.path)}">${escapeHtml(basename)}</span>
-            <button class="closed-files-popover-remove" type="button" aria-label="Remove from review session">×</button>
+            <button class="closed-files-popover-path" type="button" title="Click to reopen — ${escapeHtml(f.path)}">${escapeHtml(basename)}</button>
+            <button class="closed-files-popover-remove" type="button" aria-label="Remove from review session" title="Remove from review session">×</button>
           </div>`;
       })
       .join("");
@@ -150,6 +150,26 @@ function setupClosedFilesIndicator() {
         if (path) {
           removeClosedFile(path);
           void pushTabStatesToRust();
+        }
+      });
+    });
+    popover.querySelectorAll<HTMLButtonElement>(".closed-files-popover-path").forEach((p) => {
+      p.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        const item = (e.currentTarget as HTMLElement).closest<HTMLElement>(
+          ".closed-files-popover-item"
+        );
+        const path = item?.dataset.path;
+        if (!path) return;
+        popover.hidden = true;
+        try {
+          await loadFile(path, "append");
+          hideEmptyState();
+          // Re-opening replaces "remembered" with "live" — drop from closed list.
+          removeClosedFile(path);
+          void pushTabStatesToRust();
+        } catch (error) {
+          console.error("Failed to reopen closed file:", path, error);
         }
       });
     });

--- a/file-review/src/main.ts
+++ b/file-review/src/main.ts
@@ -672,16 +672,7 @@ async function registerTauriCloseGuard() {
   let allowClose = false;
 
   await tauriWindow.onCloseRequested(async (event) => {
-    const dirtyTabs = tabManager.tabs.filter((t) => t.hasUnsavedChanges);
-    const anyDirty = dirtyTabs.length > 0;
-    console.log("[close-guard]", {
-      allowClose,
-      anyDirty,
-      tabs: tabManager.tabs.map((t) => ({
-        path: t.path,
-        dirty: t.hasUnsavedChanges,
-      })),
-    });
+    const anyDirty = tabManager.tabs.some((t) => t.hasUnsavedChanges);
     if (allowClose || !anyDirty) {
       return;
     }

--- a/file-review/src/shortcuts.ts
+++ b/file-review/src/shortcuts.ts
@@ -15,6 +15,7 @@ export const shortcuts: Shortcut[] = [
   { keys: "⌘T", description: "New tab (open file)" },
   { keys: "⌘W", description: "Close active tab" },
   { keys: "⌘1…9", description: "Switch to Nth tab" },
+  { keys: "⌘N / ⌘P", description: "Next / previous tab" },
   { keys: "⌘⇧T", description: "Toggle theme (light/dark)" },
   { keys: "⌘M", description: "Toggle markdown view (raw/pretty)" },
   { keys: "⌘⇧V", description: "Toggle vim mode" },
@@ -140,6 +141,8 @@ export interface ShortcutHandlers {
   newTab?: () => void;
   closeTab?: () => void;
   jumpToTab?: (n: number) => void;
+  nextTab?: () => void;
+  prevTab?: () => void;
   zoomIn?: () => void;
   zoomOut?: () => void;
   undo?: () => void;
@@ -181,6 +184,16 @@ export function initShortcuts(handlers: ShortcutHandlers) {
     if (/^[1-9]$/.test(e.key) && !e.shiftKey) {
       e.preventDefault();
       handlers.jumpToTab?.(parseInt(e.key, 10));
+      return;
+    }
+    if (key === "n" && !e.shiftKey) {
+      e.preventDefault();
+      handlers.nextTab?.();
+      return;
+    }
+    if (key === "p" && !e.shiftKey) {
+      e.preventDefault();
+      handlers.prevTab?.();
       return;
     }
 

--- a/file-review/src/styles.css
+++ b/file-review/src/styles.css
@@ -134,6 +134,11 @@ body {
   border-bottom: 1px solid var(--border-color);
 }
 
+.tab-strip-row > .tab-strip {
+  flex: 1;
+  min-width: 0;
+}
+
 .tab-strip-row:has(.tab-strip:empty):has(.closed-files-btn[hidden]) {
   display: none;
 }
@@ -222,6 +227,17 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  padding: 0;
+  font-size: inherit;
+}
+
+.closed-files-popover-path:hover {
+  color: var(--accent-color);
 }
 
 .closed-files-popover-remove {

--- a/file-review/src/styles.css
+++ b/file-review/src/styles.css
@@ -126,6 +126,120 @@ body {
   font-size: 14px;
 }
 
+/* Tab strip row (tab strip + closed-files indicator) */
+.tab-strip-row {
+  display: flex;
+  align-items: stretch;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.tab-strip-row:has(.tab-strip:empty):has(.closed-files-btn[hidden]) {
+  display: none;
+}
+
+.closed-files-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  margin: 4px 8px 0 0;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+
+.closed-files-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.closed-files-btn .icon {
+  font-size: 14px;
+}
+
+.closed-files-count {
+  background: var(--accent-color);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0 6px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  min-width: 16px;
+  text-align: center;
+}
+
+.closed-files-popover {
+  position: absolute;
+  top: 88px;
+  right: 8px;
+  z-index: 200;
+  min-width: 280px;
+  max-width: 400px;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
+  padding: 8px 0;
+  font-size: 12px;
+}
+
+.closed-files-popover-header {
+  padding: 4px 12px 8px;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.closed-files-popover-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  color: var(--text-primary);
+}
+
+.closed-files-popover-item:hover {
+  background: var(--bg-hover);
+}
+
+.closed-files-popover-path {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+}
+
+.closed-files-popover-remove {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 2px 6px;
+  font-size: 14px;
+  line-height: 1;
+  border-radius: 3px;
+}
+
+.closed-files-popover-remove:hover {
+  background: var(--bg-hover);
+  color: var(--danger-color);
+}
+
 /* Tab strip */
 .tab-strip {
   display: flex;

--- a/file-review/src/styles.css
+++ b/file-review/src/styles.css
@@ -1238,6 +1238,26 @@ body {
   border-top: 1px solid var(--border-color);
 }
 
+.quit-confirm-footer kbd {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 5px;
+  font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+.quit-confirm-footer .primary-btn kbd {
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(0, 0, 0, 0.25);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
 /* === Syntax Highlighting (dark theme - VS Code dark+) === */
 #preview-container .hljs-keyword { color: #569cd6; }
 #preview-container .hljs-string { color: #ce9178; }


### PR DESCRIPTION
## Summary
Hotfix series on top of #23. Branch was originally created to debug a Cmd+Q regression and grew into a small UX bundle.

- **Fix Cmd+Q broken-after-merge** — adds `core:window:allow-destroy` capability and uses `tauriWindow.destroy()` from inside the close-guard handler. Without these, Tauri 2 silently no-ops the close after the JS handler returns without preventing.
- **3-button dialog now actually quits** — uses `destroy()` instead of re-entering `close()`, so "Save and quit" / "Quit anyway" terminate the window in one click.
- **Q / S keyboard shortcuts in the dialog** — visible as `<kbd>` hints. `Esc` cancels, `Q` quits without saving, `S` saves all dirty tabs and quits.
- **No more stacked dialog backdrops** on rapid Cmd+Q.
- **Cmd+W on dirty tab uses the same 3-button dialog** (Save and close / Close anyway / Cancel) instead of the primitive `window.confirm`.
- **Closed-files session list** — non-discarded tab closes are remembered for the rest of the session so the final window-close stdout summary still groups their comments under `## <path>` headers. A ☰ indicator with count appears at the right of the tab strip; click to expand a popover. Each entry is clickable to reopen the file as a tab; × drops it from the session entirely.
- **Cmd+N / Cmd+P rotate the active tab** with wrap-around.

## Test plan
- [ ] `bun run dev -- ./test-files/with-mermaid.md` — Cmd+Q closes cleanly when no edits
- [ ] Add a comment, Cmd+Q → dialog with `Esc`/`Q`/`S` shortcuts. `S` saves and quits in one shot.
- [ ] Open two files, edit both, Cmd+W on one → dialog. Save and close → file persisted, ☰ badge shows `1`. Click the ☰ → popover lists path. Click path → reopens as a tab and drops from closed list. × removes it.
- [ ] Cmd+N / Cmd+P cycle tabs (wrap at ends).
- [ ] Close window with mix of open + closed-and-saved tabs → stdout summary contains `## <path>` headers for both.