### PR TITLE
feat(cc-base): SessionStart workflow frame (v2.1.0)

### DIFF
--- a/cc-plugin/base/.claude-plugin/plugin.json
+++ b/cc-plugin/base/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "desplega",
     "description": "Plugin for effective agentic development",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "author": {
         "name": "desplega.ai",
         "email": "contact@desplega.ai"
@@ -16,6 +16,17 @@
     ],
     "license": "MIT",
     "hooks": {
+        "SessionStart": [
+            {
+                "matcher": "startup|clear",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+                    }
+                ]
+            }
+        ],
         "PreToolUse": [
             {
                 "matcher": "Write|Edit",

--- a/cc-plugin/base/README.md
+++ b/cc-plugin/base/README.md
@@ -123,6 +123,7 @@ Inside you will find:
 
 The plugin also registers a few lifecycle hooks (see [`hooks/`](./hooks) and the `hooks` block in [`.claude-plugin/plugin.json`](./.claude-plugin/plugin.json)):
 
+- **Workflow frame** (`session_start.py` on `SessionStart`, new/cleared sessions only) — injects a short, factual reminder once per fresh context: push research/exploration to sub-agents (`Explore`, `/desplega:research`), persist to `thoughts/`, hand off between stages instead of `/compact`. One-time, so no per-turn nagging.
 - **Context-window pressure warnings** (`context_warn.py` on `UserPromptSubmit`, `stop_confirm.py` on `Stop`) — the enforcement arm of "Problem 2" above. As the session fills up they nudge you to **offload to sub-agents, persist progress to `thoughts/`, and avoid `/compact`** (so those files keep their value); at high pressure they pause the session so you can hand off to a fresh one instead of grinding on in a degraded context.
 - **`thoughts/` validation** (`validate-thoughts.py` on `Write|Edit`) — keeps thoughts-directory writes well-formed.
 - **Plan checkbox tracking** (`plan_checkbox_*.py`) — keeps plan progress in sync during `implement`.

--- a/cc-plugin/base/hooks/session_start.py
+++ b/cc-plugin/base/hooks/session_start.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject a short, factual frame about the desplega
+context-offloading workflow.
+
+Fires on new / cleared sessions only (the matcher in plugin.json filters to
+`startup|clear`), so it costs at most a few lines once per fresh context — no
+per-turn nagging. The text is phrased as descriptive project info rather than
+imperative commands, so it reads as context instead of tripping Claude's
+prompt-injection defenses (which would surface it to the user verbatim).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+FRAME = (
+    "The desplega workflow keeps the main thread's context small — context "
+    "quality degrades noticeably past ~40% of the window:\n"
+    "- Push research and codebase exploration to sub-agents (the `Explore` "
+    "agent, or `/desplega:research`) so raw file/search output never lands in "
+    "the main context.\n"
+    "- Persist progress to `thoughts/` files and hand off to a fresh session "
+    "between major stages (`/desplega:brainstorm` → `/desplega:research` → "
+    "`/desplega:create-plan` → `/desplega:implement-plan`) instead of `/compact`."
+)
+
+
+def main() -> None:
+    try:
+        json.load(sys.stdin)  # consume the payload; we don't need any field
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": FRAME,
+                }
+            }
+        )
+    )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a `SessionStart` hook to the desplega **base** plugin that injects a short, factual workflow frame once per new/cleared session.

- New `hooks/session_start.py` — matcher `startup|clear`, so it fires once per fresh context, never per-turn (no nagging).
- Nudges: push research/exploration to sub-agents (`Explore`, `/desplega:research`), persist progress to `thoughts/`, hand off between stages (`/desplega:brainstorm → /desplega:research → /desplega:create-plan → /desplega:implement-plan`) instead of `/compact`.
- Phrased as descriptive project info (not imperative commands) so it reads as context rather than tripping Claude's prompt-injection defenses.
- README hooks section updated; plugin bumped `2.0.1 → 2.1.0`.

## Why not also capture the model at SessionStart?

The original idea was to use `SessionStart` — the only hook the docs say receives a `model` field — to detect the 1M context variant precisely. An empirical probe killed it: CC 2.1.162's `SessionStart` payload has **no `model` field** (a `claude -p --settings` probe returned only `session_id, transcript_path, cwd, hook_event_name, source`). So window detection stays on the family-default + observed-peak backstop already shipped in 2.0.1 (commit `18520c4`, on `main`).

## Testing

- compile + `plugin.json` validity + SessionStart wiring (`startup|clear`)
- unit: correct `additionalContext` contract; contains the `/desplega:` commands; robust to empty/garbage stdin (still exits 0)
- **E2E**: a real `claude -p` session received the injected frame and paraphrased it back correctly, including the `/desplega:` command chain
