### PR TITLE
docs(file-review-plugin): reconcile skill with binary (multi-file, CLI, web, config)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,3 +84,13 @@ After making changes to `file-review/`, follow this sequence:
 4. **Commit Cargo.lock**: The build updates `file-review/src-tauri/Cargo.lock` — commit and push it separately
 
 Use `bun run dev -- /path/to/file.md` for E2E testing before release.
+
+<important if="you change the file-review binary (`file-review/`) OR its plugin skill (`cc-plugin/file-review/`)">
+
+The binary and the plugin skill must stay in sync — the skill **documents** what the binary does (CLI flags, keyboard shortcuts, output formats, config). They have drifted before.
+
+- Change the binary's CLI/shortcuts/output/config behavior → update `cc-plugin/file-review/skills/file-review/SKILL.md` (and `commands/`) to match, treating the binary source as the source of truth (`src-tauri/src/{main,lib,comments,config,web_server}.rs`, `src/shortcuts.ts`).
+- Change the skill → verify every documented flag/shortcut/format still matches the current binary.
+- Either way, bump the plugin version in `cc-plugin/file-review/.claude-plugin/plugin.json` (per the Plugin versioning rules above).
+</important>
+

--- a/cc-plugin/file-review/.claude-plugin/plugin.json
+++ b/cc-plugin/file-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "file-review",
-  "description": "Launch file-review GUI for reviewing markdown files with inline comments",
-  "version": "1.5.0",
+  "description": "Launch file-review GUI for reviewing one or more markdown files with inline comments",
+  "version": "1.6.0",
   "author": {
     "name": "desplega.ai"
   }

--- a/cc-plugin/file-review/commands/file-review.md
+++ b/cc-plugin/file-review/commands/file-review.md
@@ -1,6 +1,6 @@
 ---
 description: Open a file in the file-review GUI for adding inline comments
-argument-hint: [file_path] [--bg] [--silent] [--json]
+argument-hint: [file_path] [--silent] [--json]
 ---
 
 # File Review
@@ -12,5 +12,5 @@ Shortcut command for backward compatibility. Delegates to the unified `file-revi
 When the user invokes `/file-review [path]`:
 
 1. Follow the **Review a File** section of the `file-review:file-review` skill
-2. Pass through any arguments and flags (`--bg`, `--silent`, `--json`)
+2. Pass through any arguments and flags (`--silent`, `--json`)
 3. After the GUI closes, follow the **Process Comments** section of the same skill

--- a/cc-plugin/file-review/skills/file-review/SKILL.md
+++ b/cc-plugin/file-review/skills/file-review/SKILL.md
@@ -38,6 +38,8 @@ brew install file-review
 
 Verify: `which file-review`
 
+> The Homebrew build is **native-only** — it does not include web mode. For `--web`/`--tunnel` you must **build from source** with `bun run install:web` (see **Advanced: Web / tunnel mode**).
+
 ### Manual Install (from source)
 
 Prerequisites: **bun**, **Rust**
@@ -46,10 +48,16 @@ Prerequisites: **bun**, **Rust**
 git clone https://github.com/desplega-ai/ai-toolbox.git
 cd ai-toolbox/file-review
 bun install
-bun run install:app
+bun run install:app   # native binary
+# or, for web/tunnel mode:
+bun run install:web   # web-feature binary
 ```
 
-This symlinks to `~/.local/bin/file-review`. Ensure that's in PATH.
+Both symlink to `~/.local/bin/file-review` (ensure that's in PATH).
+
+- `bun run install:app` builds the native (Tauri) binary. It does **not** include web mode — passing `--web` to it errors out (`main.rs:101-105`).
+- `bun run install:web` builds the `web`-feature binary required for `--web`/`--tunnel`.
+- Maintainers cutting a release use `bun run release` (handles version sync across the three manifests + build), not a bare `install:*`.
 
 ### Troubleshooting
 
@@ -74,11 +82,17 @@ Check for recently created or modified files in the current session:
 - Research documents in `thoughts/<username|shared>/research/`
 - Any markdown files created or updated during the conversation
 
-Propose candidates to the user via AskUserQuestion.
+**Pending review batches:** also surface files that still contain *active* `review-(start|line-start)` markers — leftover review sessions whose comments were never processed:
+```bash
+grep -rlE '<!-- *review-(start|line-start)\(' thoughts/taras/ thoughts/shared/ --include="*.md" 2>/dev/null | head -20
+```
+Re-verify each hit against the **Extraction Patterns** regexes (Process Comments below) before proposing — a bare `grep` also matches files that merely quote the marker syntax (like this plan), so only offer files with a full parseable match.
+
+Propose all candidates (recent files + pending batches) via a single **multi-select AskUserQuestion**. On selection, launch `file-review "<p1>" "<p2>" …` (0–N absolute paths, one tab each) and flow into **Process Comments**.
 
 ### If path provided
 
-1. **Verify the file exists** and is readable.
+1. **Verify the file(s) exist** and are readable.
 
 2. **Check if file-review is installed:**
    ```bash
@@ -86,22 +100,24 @@ Propose candidates to the user via AskUserQuestion.
    ```
    If not found, jump to the **Install** section above.
 
-3. **Launch the GUI:**
+3. **Launch the GUI** (one or more files):
    ```bash
-   file-review "<absolute_path>"
+   file-review "<p1>" "<p2>" …
    ```
+   - The launch may pass **0–N absolute paths**. Each positional path opens in its own tab (`main.rs:50-56`, `lib.rs:23-48`): one path → a single tab; multiple files → one tab per path.
+   - Additional files can also be opened **in-session**: `Cmd+T` / `Cmd+O` (the file picker is multi-select) or drag-and-drop onto the window.
    - Use the Bash tool with `run_in_background: true` and `timeout: 600000` (max allowed — 10 minutes)
    - Do **NOT** append `&` to the command — the process must block until the user closes the GUI
    - Do **NOT** use `--bg` — let the Bash tool handle backgrounding
    - When the background task completes, Claude is automatically notified and receives stdout (review comments)
 
-   Other CLI flags: `--silent` (no comment output), `--json` (JSON output).
+   See **Binary / CLI Reference** below for all flags (`--silent`, `--json`, web mode, …) and the exact output formats.
 
 4. **Inform the user:**
    ```
-   I've opened file-review for <filename>.
+   I've opened file-review for <file(s)>.
 
-   Shortcuts: Cmd+K (add comment), Cmd+S (save), Cmd+Q (quit), Cmd+/ (help)
+   Shortcuts: Cmd+K (add comment), Cmd+T (new tab), Cmd+S (save), Cmd+Q (quit), Cmd+/ (help)
    ```
    No need to ask the user to notify you when done — you will be automatically notified when the GUI closes.
 
@@ -111,8 +127,10 @@ Propose candidates to the user via AskUserQuestion.
 
    [abc123] Line 15 (inline):
        "highlighted code"
-       -> Comment text here
+       → Comment text here
    ```
+
+   When multiple tabs were open, the output is grouped per file under `## <path>` headers (see **Binary / CLI Reference**).
 
    Present the output, then proceed to **Process Comments** below.
 
@@ -122,11 +140,101 @@ Propose candidates to the user via AskUserQuestion.
 |----------|--------|
 | Cmd+K | Add comment to selection |
 | Cmd+S | Save file |
-| Cmd+Q | Quit application |
-| Cmd+/ | Show all shortcuts |
-| Cmd+T | Toggle theme |
-| Cmd+Shift+V | Toggle vim mode |
+| Cmd+T | New tab (open file) |
 | Cmd+O | Open file |
+| Cmd+W | Close active tab |
+| Cmd+1…9 | Switch to Nth tab |
+| Cmd+N / Cmd+P | Next / previous tab |
+| Cmd+M | Toggle markdown view (raw/pretty) |
+| Cmd+Shift+T | Toggle theme (light/dark) |
+| Cmd+Shift+V | Toggle vim mode |
+| Cmd++ / Cmd+- | Zoom in / out |
+| Cmd+Z / Cmd+Shift+Z | Undo / redo |
+| Cmd+Q | Quit application |
+| Cmd+/ | Show all shortcuts (incl. preview vim nav & search) |
+
+Preview-mode vim navigation (`j`/`k` next/prev block, `gg`/`G` first/last, `Ctrl+D`/`Ctrl+U` page, `/` or `Cmd+F` search, `n`/`N` next/prev match) is listed in the in-app `Cmd+/` shortcuts modal.
+
+### Binary / CLI Reference
+
+`file-review [OPTIONS] [FILE]...` — mirrors `file-review --help` (`main.rs:280-318`).
+
+| Flag | Meaning |
+|------|---------|
+| `-h`, `--help` | Show help (includes the config path + current contents) |
+| `-v`, `--version` | Show version |
+| `-s`, `--silent` | Suppress comment output on close |
+| `-j`, `--json` | Emit JSON on close |
+| `-w`, `--web` | Start in web-server mode (requires the `web`-feature build) |
+| `-o`, `--open` | Auto-open the browser (requires `--web`) |
+| `-t`, `--tunnel` | Enable localtunnel for remote access (requires `--web`) |
+| `--subdomain NAME` | Request a specific tunnel subdomain (requires `--tunnel`) |
+| `--port PORT` | HTTP server port (default: **3456**) |
+| `[FILE]...` | 0–N file paths; one tab per path |
+| `-` / piped stdin | `file-review -` or `cat content.md \| file-review` reads stdin into a temp file |
+
+**Output formats** (printed to stdout on close, unless `--silent`):
+
+- **Native, single tab — flat** (`comments.rs:151-179`):
+  ```
+  === Review Comments (N) ===
+
+  [abc123] Line 15 (inline):
+      "highlighted code"
+      → Comment text here
+  ```
+- **Native, multiple tabs — grouped:** each file's block is prefixed with a `## <path>` header, blocks joined by blank lines (`lib.rs:254-271`):
+  ```
+  ## /tmp/a.md
+
+  === Review Comments (1) ===
+  …
+
+  ## /tmp/b.md
+
+  === Review Comments (1) ===
+  …
+  ```
+- **JSON (`--json`)** (`lib.rs:223-253`): single tab → a **bare array** of comment objects; multiple tabs → an array of `{ "path", "comments": [...] }` groups. Tabs with no comments are omitted.
+- **stdin mode** (`comments.rs:211-263`): a combined block with `=== File ===`, `=== Content ===`, and `=== Review Comments ===` sections (the comments header becomes `=== Review Comments (content modified) ===` when the piped content was edited).
+
+### Advanced: Web / tunnel mode
+
+Web mode serves the reviewer over HTTP instead of the native window — useful for remote review. It is **explicitly single-file**: `run_web_mode` takes one path (`main.rs:143-174`), so multi-file tabs are native-only.
+
+```bash
+file-review --web "<path>"                          # serve on http://127.0.0.1:3456
+file-review --web --open "<path>"                   # also auto-open the browser
+file-review --web --tunnel "<path>"                 # expose via localtunnel for remote access
+file-review --web --tunnel --subdomain myname "<path>"
+file-review --web --port 8080 "<path>"              # custom port (default 3456)
+```
+
+- `--open` and `--tunnel` require `--web`; `--subdomain` requires `--tunnel`.
+- Comments come back exactly like the native close: when the page's Quit is triggered (browser/GUI close), the server re-reads the file, prints the comment block to stdout, and shuts down (`web_server.rs:279-356`). Feed that into **Process Comments** below.
+
+**Install caveat:** web mode needs the `web`-feature build. A plain `bun run install:app` binary — and the Homebrew build — is **native-only** and **rejects `--web`** with `Error: Web mode requires the 'web' feature` (`main.rs:101-105`). Build the web binary from source:
+
+```bash
+cd ai-toolbox/file-review && bun run install:web
+```
+
+Because **Homebrew is native-only**, brew users who want web mode must build from source this way.
+
+### Config
+
+Persistent settings live in `~/.file-reviewer.json` (`config.rs:11-22,44-48`). Keys (must match the `AppConfig` struct):
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `theme` | string | `"dark"` / `"light"` |
+| `vim_mode` | bool | Vim keybindings in the editor |
+| `font_size` | number | Editor font size (default 14) |
+| `markdown_raw` | bool | Default to raw markdown vs. rendered preview |
+| `save_on_quit` | bool | When **true**, edits/markers persist on quit **without** an explicit `Cmd+S` |
+| `window` | object | `{ "width", "height" }` |
+
+`file-review --help` prints the config path and current contents; the in-app `Cmd+/` shortcuts modal also exposes it.
 
 ---
 
@@ -163,49 +271,65 @@ multiple lines
 
 ### Workflow
 
-**Step 1: Read and Parse**
+**Step 1: Determine source and parse**
 
-Read the file, extract all comments, present a summary:
+The close-output (stdout returned when the GUI closes) is the **source of truth** for which files were reviewed and what the comments are. **Consume that output directly; re-read a file from disk only if needed** — when the run used `--silent`, when stdout was truncated, or when you need the exact on-disk spans to strip markers (apply the **Extraction Patterns** to the file content in that case).
+
+- **Single tab** → flat `=== Review Comments (N) ===` block → process that one file (the default path).
+- **Multiple tabs** → output grouped under `## <path>` headers → parse each section into `{ path, comments }`.
+
+Present a per-file summary:
 
 ```
-Found 3 review comments in <filename>:
+Found 5 review comments across 2 files:
 
-1. [inline] "implement caching" -> "Consider using Redis"
-2. [line] "function fetchData()..." -> "Add error handling"
-3. [inline] "TODO" -> "Please complete this"
+thoughts/taras/plans/…plan.md (3):
+  1. [inline] "implement caching" → "Consider using Redis"
+  2. [line]   "function fetchData()…" → "Add error handling"
+  3. …
+thoughts/taras/research/…md (2):
+  …
 ```
 
-**Step 2: Process Each Comment**
+For a single file, collapse to the flat `Found N review comments in <file>:` form.
 
-For each comment, show context and use AskUserQuestion:
+**Step 2: Process each comment, grouped by file**
+
+Work one file at a time. For each comment, show context and use AskUserQuestion:
 
 | Question | Options |
 |----------|---------|
-| "Comment N of M: <feedback summary>" | 1. Apply edit, 2. Acknowledge (remove markers only), 3. Skip |
+| "Comment N of M in <file>: <feedback summary>" | 1. Apply edit, 2. Acknowledge (remove markers only), 3. Skip |
 
-- **Apply edit**: Propose changes, apply after confirmation, remove markers.
-- **Acknowledge**: Remove markers, preserve content. Recommend this for praise/FYI.
-- **Skip**: Leave as-is, move on.
+- **Apply edit**: draft the change for the highlighted span addressing the feedback, apply after confirmation, then strip the markers. (You may show a short before/after or 2-line unified diff first — keep it terse, not a ceremony.)
+- **Acknowledge**: strip the markers, preserve content unchanged. Recommend for praise/FYI.
+- **Skip**: leave marker and content as-is.
 
-**Step 3: Remove Markers**
+**Step 3: Strip markers (on the on-disk file)**
 
-- Inline: replace `<!-- review-start(ID) -->text<!-- review-end(ID): feedback -->` with `text`
-- Line: replace the full block with just the content lines
+Edit each touched file directly, matching the captured full marker:
+- Inline: replace `<!-- review-start(ID) -->text<!-- review-end(ID): feedback -->` with `text`.
+- Line: replace the full block with just the inner content lines.
 
-**Step 4: Final Summary**
+Process files sequentially (read → edit → next file) — never concurrent writes to one file.
+
+**Step 4: Final summary (per-file + totals)**
 
 ```
-Processing complete!
+Processing complete (2 files):
 
-- Applied edits: 2
-- Acknowledged: 1
-- Skipped: 0
+thoughts/taras/plans/…plan.md — Applied 1, Acknowledged 2, Skipped 0
+thoughts/taras/research/…md   — Applied 0, Acknowledged 1, Skipped 0
 
-File saved.
+Totals: Applied 1, Acknowledged 3, Skipped 0
+All markers stripped from touched files; files saved.
 ```
+
+For a single reviewed file, collapse to one flat block (Applied / Acknowledged / Skipped).
 
 ### Special Cases
 
-- **FYI/Praise** ("LGTM", "Nice work"): Recommend Acknowledge as default
-- **Empty feedback**: Ask if user wants to remove markers
-- **Unclear feedback**: Use AskUserQuestion to clarify reviewer intent
+- **FYI/Praise** ("LGTM", "Nice work"): Recommend Acknowledge as default.
+- **Empty feedback**: Ask if the user wants to remove the markers.
+- **Unclear feedback**: Use AskUserQuestion to clarify reviewer intent before applying.
+- **Batch hint**: when comments came from a multi-file batch, note "X of N markers from the same review session" in the per-comment prompt.

--- a/thoughts/taras/plans/2026-06-26-file-review-skill-reconcile.md
+++ b/thoughts/taras/plans/2026-06-26-file-review-skill-reconcile.md
@@ -1,0 +1,260 @@
+---
+date: 2026-06-26
+author: Claude (for Taras)
+last_updated: 2026-06-26
+last_updated_by: Claude (phase-running, Phase 5 — Change #1 only)
+status: completed
+autonomy: autopilot
+topic: "Reconcile file-review plugin skill: port multi-file/batch behavior into source, fix factual bugs"
+related_research: thoughts/taras/research/2026-06-26-file-review-skill-binary-gaps.md
+tags: [plan, file-review, cc-plugin, skill, multi-file]
+---
+
+# file-review Plugin Skill Reconcile — Implementation Plan
+
+## Overview
+
+Update the **plugin-source** file-review skill (`cc-plugin/file-review/`) so it matches what the binary (`file-review/`, v1.10.0) actually does — multi-file tabs, batch review, stdin, web mode, config — and fix the factual bugs the research found. The genuinely useful multi-file/batch behavior already exists in a **diverged personal copy** (`~/.agents/skills/file-review/SKILL.md`, surfaced via the `~/.claude/skills/file-review` symlink); we port a **tightened** version of it into source rather than re-inventing.
+
+- **Motivation**: The marketplace-shipped skill (`cc-plugin/file-review/`, plugin `1.5.0`) predates multi-file/tabs (landed 2026-05-05) and web mode. It documents a single-file tool, has a wrong shortcut table, and advertises a non-existent `--bg` flag. Meanwhile a personal copy already implements multi-file/batch but was never ported back and is over-engineered/rambly.
+- **Related**: `thoughts/taras/research/2026-06-26-file-review-skill-binary-gaps.md` (gap analysis + resolved decisions); source-of-good-behavior `~/.agents/skills/file-review/SKILL.md`; binary truth in `file-review/src-tauri/src/{main,lib,comments,config}.rs` and `file-review/src/shortcuts.ts`.
+
+## Current State Analysis
+
+Three copies of this skill exist:
+
+| Copy | Path | State |
+|------|------|-------|
+| **Plugin source** (target) | `cc-plugin/file-review/skills/file-review/SKILL.md` (+ `install/`, `process-review/`, `commands/`) | Stale, single-file. Wrong shortcut table (`Cmd+T`="Toggle theme"; actually New Tab — `shortcuts.ts:15`). Phantom `--bg` in `commands/file-review.md:2,14`. Example arrow `->` vs binary `→`. |
+| **Marketplace cache** | `~/.claude/plugins/cache/desplega-ai-toolbox/file-review/1.5.0/` | Byte-identical to plugin source (stale). Regenerated on plugin update — **do not edit directly**. |
+| **Personal copy** (port-from) | `~/.agents/skills/file-review/SKILL.md` (via `~/.claude/skills/file-review` symlink) | Already has multi-file launch, "Review batches v1" live-marker discovery, `parseAllMarkersWithContext` util, batch-aware Process Comments with diff previews. Rambly: "Phase 2/3/4 note (final)", inline node harnesses, self-contradicting prose. This is the version `/file-review` actually triggers today. |
+
+**Binary truth** (already verified in research; load-bearing refs):
+- Multi-file: all positional args → one tab each (`file-review/src-tauri/src/main.rs:50-56`, `lib.rs:23-48`). Grouped output `## <path>` when >1 tab, flat for single tab (`lib.rs:218-271`). JSON: array of `{path, comments}` multi-tab, bare array single (`lib.rs:223-253`).
+- Shortcuts: canonical map at `file-review/src/shortcuts.ts:8-33`.
+- stdin: `main.rs:62-91`; distinct output `comments.rs:212-263`.
+- Web/tunnel: `main.rs:143-242`, `web_server.rs`; `--web` needs `web` feature (`main.rs:101-105`, built by `install:web` — `package.json:13-16`).
+- Config `~/.file-reviewer.json`: `config.rs:11-22,44-48`.
+
+**Resolved decisions** (Taras, 2026-06-26): Process Comments consumes the grouped close-output as source of truth, re-reading from disk only if needed; web mode stays explicitly single-file; Homebrew assumed native-only → web docs need an `install:web`-from-source caveat.
+
+## Desired End State
+
+`cc-plugin/file-review/` documents the real tool: multi-file launch + tabs, accurate shortcuts, a CLI reference mirroring `--help`, batch-aware Process Comments, and web/config/install notes — in **tight** prose. Plugin version bumped. The personal copy no longer silently diverges. Verifiable via grep assertions on the edited files + a real multi-file round-trip with the binary.
+
+## What We're NOT Doing
+
+- **No changes to the Rust/TS binary** (`file-review/`). This is docs/skill only.
+- **Not making web mode multi-file** (decided: single-file).
+- **Not editing the marketplace cache** directly (it regenerates from source).
+- **Not porting the rambly scaffolding** ("Phase 2/3/4 note (final)", inline `node -e` harnesses, the `parseAllMarkersWithContext` JS verbatim) — we port the *behavior*, expressed concisely with the existing extraction regexes.
+- **Not updating `.claude-plugin/marketplace.json`** (file-review already listed; only a version bump in `plugin.json` is needed).
+- **Not touching the `wts`/other plugins.**
+
+## Implementation Approach
+
+- **Source of truth = the binary.** Every documented flag/shortcut/format is checked against `main.rs`/`shortcuts.ts`/`lib.rs`, not against either skill copy.
+- **Port behavior, not prose.** Read the personal copy for *what* it does; rewrite concisely for source.
+- **Sequence low-risk → additive → reconcile.** Correctness fixes first (independently shippable), then multi-file/CLI, then batch Process Comments, then advanced docs, then version bump + personal-copy reconcile.
+- **Keep the router + thin-redirect structure** (`install/`, `process-review/` stay thin redirects; the `/file-review` + `/process-comments` commands stay backward-compat shortcuts).
+- Verification is **grep assertions** (docs have no test suite) plus one **real binary E2E** for the multi-file output format.
+
+## Quick Verification Reference
+
+- Inspect edits: `git -C /Users/taras/Documents/code/ai-toolbox diff -- cc-plugin/file-review/`
+- Marker/flag assertions: `grep -n` on the edited skill files (exact commands per phase).
+- Real round-trip: `file-review /tmp/a.md /tmp/b.md` (add a comment in each tab, close, inspect grouped stdout).
+- Version: `grep '"version"' cc-plugin/file-review/.claude-plugin/plugin.json`
+
+---
+
+## Phase 1: Correctness fixes (no new behavior)
+
+### Overview
+
+Fix the three factual bugs in the existing plugin source without adding features — independently shippable.
+
+### Changes Required:
+
+#### 1. Keyboard shortcut table
+**File**: `cc-plugin/file-review/skills/file-review/SKILL.md` (the `### Keyboard Shortcuts` table, ~lines 119-130)
+**Changes**: Rebuild the table from `file-review/src/shortcuts.ts:8-33`. Correct `Cmd+T` → **New tab (open file)**; add `Cmd+Shift+T` **Toggle theme**, `Cmd+W` close tab, `Cmd+1…9` jump to tab, `Cmd+N`/`Cmd+P` next/prev tab, `Cmd+M` toggle markdown raw/pretty, `Cmd++`/`Cmd+-` zoom, `Cmd+Z`/`Cmd+Shift+Z` undo/redo, and a row pointing to in-app `Cmd+/` for the full preview-vim/search list. Keep correct rows (`Cmd+K`, `Cmd+S`, `Cmd+Q`, `Cmd+/`, `Cmd+Shift+V`, `Cmd+O`).
+
+#### 2. Phantom `--bg` flag
+**File**: `cc-plugin/file-review/commands/file-review.md`
+**Changes**: Remove `--bg` from the `argument-hint` frontmatter (line 2) and from the "Pass through any arguments and flags (`--bg`, ...)" instruction (line 14). Backgrounding is handled by the Bash tool's `run_in_background`, consistent with `SKILL.md:95`.
+
+#### 3. Example output arrow
+**File**: `cc-plugin/file-review/skills/file-review/SKILL.md` (example block ~line 114)
+**Changes**: Change `-> Comment text here` to `→ Comment text here` to match `comments.rs:175`.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] No `--bg` anywhere in the command wrapper: `! grep -rn -- '--bg' cc-plugin/file-review/commands/`
+- [x] `Cmd+T` no longer mapped to theme: `! grep -n 'Cmd+T | Toggle theme' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] Theme toggle now documented as Shift: `grep -n 'Cmd+Shift+T' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] Tab shortcuts present: `grep -nE 'Cmd\+W|Cmd\+1' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] Arrow fixed (no ASCII arrow in the example): `grep -n '→ Comment text here' cc-plugin/file-review/skills/file-review/SKILL.md`
+
+#### Automated QA:
+- [x] Agent diffs the new shortcut table line-by-line against `file-review/src/shortcuts.ts:8-33` and confirms every documented binding exists in the handler (`shortcuts.ts:152-237`) with no invented bindings.
+
+#### Manual Verification:
+- [ ] Spot-check: open the GUI (`file-review <any.md>`), press `Cmd+T` → a new tab/file picker opens (not a theme flip), confirming the doc now matches reality.
+
+**Implementation Note**: After this phase, pause for manual confirmation. Independently shippable.
+
+---
+
+## Phase 2: Multi-file launch + Binary/CLI Reference
+
+### Overview
+
+Make the **Review a File** section multi-file aware and add a single-source-of-truth **CLI Reference** subsection mirroring `--help`.
+
+### Changes Required:
+
+#### 1. Review a File — multi-file launch
+**File**: `cc-plugin/file-review/skills/file-review/SKILL.md` (the `## Review a File` → `### If path provided` block, ~lines 79-117)
+**Changes**: Document `file-review "<p1>" "<p2>" …` opening one tab per path (`main.rs:50-56`, `lib.rs:23-48`); note additional files open in-session via `Cmd+T`/`Cmd+O` (multi-select picker) or drag-drop. State the contract that the launch may pass 0–N absolute paths. Keep the `run_in_background: true` / `timeout: 600000` / no-`&` / no-`--bg` launch rules.
+
+#### 2. New "Binary / CLI Reference" subsection
+**File**: `cc-plugin/file-review/skills/file-review/SKILL.md` (new subsection, e.g. under Review a File or a top-level `## CLI Reference`)
+**Changes**: Add a concise flag table (from research §1 / `main.rs:280-318`): `-h/--help`, `-v/--version`, `-s/--silent`, `-j/--json`, `-w/--web`, `-o/--open`, `-t/--tunnel`, `--subdomain`, `--port` (default 3456), `[FILE]...`, stdin (`-` / piped). Document the **output formats**: native single-tab flat (`=== Review Comments (N) ===`), native multi-tab grouped under `## <path>` headers, JSON shapes (bare array vs `[{path,comments}]`), and the stdin `=== File === / === Content === / === Review Comments ===` block (`comments.rs:151-263`).
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Multi-file launch documented: `grep -nE 'p1.*p2|one tab per|multiple file' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] CLI reference covers web/port flags: `grep -nE '\-\-web|\-\-port|\-\-tunnel|\-\-subdomain' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] Grouped-output format documented: `grep -n '## <path>' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] stdin usage documented: `grep -nE 'stdin|cat .* \| file-review' cc-plugin/file-review/skills/file-review/SKILL.md`
+
+#### Automated QA:
+- [x] Agent cross-checks the CLI flag table against `file-review/src-tauri/src/main.rs:280-318` (`print_help`) — every flag in `--help` appears in the doc and vice-versa (no invented flags, default port = 3456).
+
+#### Manual Verification:
+- [ ] Real round-trip: `file-review /tmp/a.md /tmp/b.md`; add one comment in each tab; close. Confirm stdout is grouped under `## /tmp/a.md` and `## /tmp/b.md`, matching the newly documented format.
+
+**Implementation Note**: After this phase, pause for manual confirmation.
+
+---
+
+## Phase 3: Batch discovery + batch-aware Process Comments
+
+### Overview
+
+Port the useful "batch" behavior from the personal copy, tightened: discover files with active review markers (pending batches) for the no-path flow, and rework **Process Comments** to handle the multi-tab grouped output across N files.
+
+### Changes Required:
+
+#### 1. Pending-batch discovery (no-path flow)
+**File**: `cc-plugin/file-review/skills/file-review/SKILL.md` (`## Review a File` → `### If no path provided`)
+**Changes**: In addition to recent plan/research files, add a concise "pending review batches" discovery: grep for active `review-(start|line-start)` markers, scoped to `thoughts/taras/` + `thoughts/shared/`, then re-verify with the exact extraction regexes before proposing (so files that merely quote the pattern aren't offered). Present via multi-select AskUserQuestion. Port the *idea* from the personal copy's "Review batches v1" but in ~6 lines, no inline node harness, no "Phase N note" scaffolding.
+
+#### 2. Batch-aware Process Comments
+**File**: `cc-plugin/file-review/skills/file-review/SKILL.md` (`## Process Comments`)
+**Changes**: Rework to: (a) **consume the grouped close-output as the source of truth** — parse per `## <path>` section for paths + comments; **re-read a file from disk only when needed** (`--silent`, truncated output) per the resolved decision; (b) group the per-comment Apply/Acknowledge/Skip presentation by file; (c) on Apply/Acknowledge, strip markers from the on-disk file (existing inline/line replacement rules); (d) emit a per-file + totals final summary. Keep the existing extraction regexes and single-file flat path as the default for one tab. Drop the verbose `parseAllMarkersWithContext` code block and diff-preview ceremony unless it can be stated in ≤2 sentences.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Process Comments references grouped output: `grep -nE 'grouped|## <path>|per[- ]file' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] "consume output, re-read if needed" decision encoded: `grep -niE 're-?read .*if needed|consume .*output' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] Pending-batch discovery present + scoped: `grep -nE 'review-\(start\|line-start\)|pending review' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] No leftover "Phase 2/3/4 note" rambly scaffolding ported in: `! grep -niE 'Phase [234] note|parseAllMarkersWithContext' cc-plugin/file-review/skills/file-review/SKILL.md`
+
+#### Automated QA:
+- [x] Agent dry-runs the documented Process flow against a fixture: two temp `.md` files each containing one inline + one line marker, simulating the grouped stdout; confirms the documented steps would resolve all 4 markers and that the final summary shape lists both files with correct counts.
+
+#### Manual Verification:
+- [ ] End-to-end with the binary: review `/tmp/a.md` + `/tmp/b.md`, leave a comment in each, close, then follow the documented Process Comments steps and confirm markers are correctly stripped from both files.
+
+**Implementation Note**: After this phase, pause for manual confirmation.
+
+---
+
+## Phase 4: Web/tunnel, config, and install docs
+
+### Overview
+
+Document the advanced surfaces and fix the install instructions so web-mode users build correctly.
+
+### Changes Required:
+
+#### 1. Advanced: Web/tunnel mode
+**File**: `cc-plugin/file-review/skills/file-review/SKILL.md` (new "Advanced" subsection)
+**Changes**: Document `--web`/`--open`/`--tunnel`/`--subdomain`/`--port` (`main.rs:143-242`), comments returned on browser/GUI close (`web_server.rs:279-356`). State **explicitly single-file** (decided). Add the **install caveat**: web mode needs the `web`-feature build (`install:web`); a plain `install:app` binary rejects `--web` (`main.rs:101-105`); **Homebrew is native-only**, so brew users must build from source with `bun run install:web`.
+
+#### 2. Install section update
+**File**: `cc-plugin/file-review/skills/file-review/SKILL.md` (`## Install`) — and mirror nothing in `skills/install/SKILL.md` (stays a thin redirect)
+**Changes**: Note that `bun run install:app` gives the native binary; for web mode use `bun run install:web`. Align with project memory (releases use `bun run release`). Keep Homebrew quick-install but add the native-only note.
+
+#### 3. Config file
+**File**: `cc-plugin/file-review/skills/file-review/SKILL.md` (new short "Config" note)
+**Changes**: Document `~/.file-reviewer.json` (`config.rs:11-22,44-48`): `theme`, `vim_mode`, `font_size`, `markdown_raw`, `save_on_quit`, `window`. Call out `save_on_quit` (when true, edits/markers persist on quit without explicit save). Note `--help` and the in-app shortcuts modal expose it.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Web section single-file + install:web caveat: `grep -nE 'single-file|install:web' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] Homebrew native-only caveat present: `grep -niE 'native-only|build from source' cc-plugin/file-review/skills/file-review/SKILL.md`
+- [x] Config documented: `grep -n 'file-reviewer.json' cc-plugin/file-review/skills/file-review/SKILL.md` and `grep -n 'save_on_quit' cc-plugin/file-review/skills/file-review/SKILL.md`
+
+#### Automated QA:
+- [x] Agent verifies the documented config keys exactly match the `AppConfig` struct fields in `file-review/src-tauri/src/config.rs:11-22` (no extra/missing keys).
+
+#### Manual Verification:
+- [ ] Run `file-review --help` and confirm the doc's flag list + config path match the actual help output.
+
+**Implementation Note**: After this phase, pause for manual confirmation.
+
+---
+
+## Phase 5: Version bump + reconcile personal copy
+
+### Overview
+
+Bump the plugin version and resolve the source-vs-personal divergence so it doesn't recur.
+
+### Changes Required:
+
+#### 1. Version bump
+**File**: `cc-plugin/file-review/.claude-plugin/plugin.json`
+**Changes**: Bump `version` `1.5.0` → `1.6.0` (minor: documented new features). Optionally refresh the `description` to mention multi-file review.
+
+#### 2. Reconcile the personal copy
+**File**: `~/.agents/skills/file-review/SKILL.md` (surfaced via `~/.claude/skills/file-review`)
+**Changes**: This personal skill currently shadows the plugin and is the diverged source. Decision to surface to Taras at implementation time (it lives outside the repo): **(a)** delete it so the freshly-updated plugin skill is the single source (recommended — `/file-review` then resolves to the plugin), or **(b)** overwrite its body with the finalized plugin `SKILL.md` so the two match. Do **not** silently leave both diverging. The implementer must confirm with Taras before deleting/overwriting anything under `~/.agents/`.
+
+**Resolution (Taras, 2026-06-26):** Neither (a) nor (b) — Taras will reconcile himself by doing a fresh install via `npx skills` after this lands. `~/.agents/` left untouched by the implementer.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Version bumped: `grep -n '"version": "1.6.0"' cc-plugin/file-review/.claude-plugin/plugin.json`
+- [x] No review markers left in any edited skill file: `! grep -rnE 'review-(start|line-start)' cc-plugin/file-review/` — assertion satisfied per documented nuance: the only matches are the SKILL.md Comment Format / Extraction Patterns / strip-rule docs that legitimately describe the marker pattern (placeholder `ID` + `[a-zA-Z0-9-]+` regex); filtering those out yields zero real stray markers.
+
+#### Automated QA:
+- [x] Haiku structure/lint pass over the rewritten `SKILL.md`: headings well-formed, intent-router table intact, no orphaned references to removed sections, prose tightened (no "Phase N note" scaffolding, no inline node harness).
+
+#### Manual Verification:
+- [x] Taras confirms the personal-copy reconcile choice — will reinstall fresh via `npx skills`; implementer leaves `~/.agents/` untouched.
+- [ ] `git diff` review of the full `cc-plugin/file-review/` changeset before commit.
+
+**Implementation Note**: After this phase, pause for manual confirmation. Per project CLAUDE.md, the plugin version bump is mandatory when modifying a plugin.
+
+---
+
+## Appendix
+
+- **Follow-up plans**: none; single-session scope.
+- **Derail notes**:
+  - The marketplace cache (`~/.claude/plugins/cache/.../file-review/1.5.0/`) only refreshes when the plugin is re-installed/updated; after merge, Taras may need `/plugin` update to pull the new version locally.
+  - `skills/install/SKILL.md` and `skills/process-review/SKILL.md` are thin redirects and should stay that way — only `skills/file-review/SKILL.md` carries content.
+  - The personal copy's diff-preview-before-apply idea (unified diff + confirm) is a genuinely nice UX; if kept, state it in ≤2 sentences rather than the verbose block currently there.
+- **References**:
+  - Research: `thoughts/taras/research/2026-06-26-file-review-skill-binary-gaps.md`
+  - Binary truth: `file-review/src-tauri/src/{main,lib,comments,config,web_server}.rs`, `file-review/src/shortcuts.ts`, `file-review/package.json`
+  - Port-from: `~/.agents/skills/file-review/SKILL.md`

--- a/thoughts/taras/research/2026-06-26-file-review-skill-binary-gaps.md
+++ b/thoughts/taras/research/2026-06-26-file-review-skill-binary-gaps.md
@@ -1,0 +1,179 @@
+---
+date: 2026-06-26T13:02:35+02:00
+researcher: Claude (for Taras)
+git_commit: e70561d0657006c8757185ba330e0b3922650573
+branch: main
+repository: ai-toolbox
+topic: "Gaps between the file-review plugin skill and what the binary actually supports (e.g. multi-files), with a proposal to restructure the skill"
+tags: [research, codebase, file-review, cc-plugin, skill, multi-file, cli]
+status: complete
+autonomy: autopilot
+last_updated: 2026-06-26
+last_updated_by: Claude (for Taras)
+---
+
+# Research: file-review skill vs. binary capability gaps (+ restructure proposal)
+
+**Date**: 2026-06-26T13:02:35+02:00
+**Researcher**: Claude (for Taras)
+**Git Commit**: e70561d0657006c8757185ba330e0b3922650573
+**Branch**: main
+
+## Research Question
+What are the gaps between the file-review **skill** in `cc-plugin/file-review/` and what the **binary** in `file-review/` actually supports (e.g. multi-files), and how should the skill be changed / restructured to close them?
+
+> Note: the default `researching` skill is documentary-only, but this request explicitly asks for a proposal, so a **Proposed Restructure** section is included after the gap analysis.
+
+## Summary
+
+The skill in `cc-plugin/file-review/` describes a **single-file, GUI-only** tool. The binary in `file-review/` (package version `1.10.0`) has since grown into a **multi-file tabbed reviewer** with **stdin piping**, a **web/tunnel server mode**, a **config file**, and a substantially different **keyboard map**. The plugin manifest is at `1.5.0` and the canonical `SKILL.md` was last meaningfully edited **2026-03-12**; the multi-file/tabs feature landed **2026-05-05** (`8d9b943`, `c06b8f8`, `ee17bf6`) and web mode shortly before it (`ba8c06c`). **The skill simply predates most of what the binary now does.**
+
+The headline gap is **multi-file**: the binary accepts any number of positional path arguments and opens one tab per path (`main.rs:50-56`, `lib.rs:23-48`), then on close emits comments **grouped per file under `## <path>` headers** (`lib.rs:218-271`). The skill never mentions tabs, only ever launches `file-review "<path>"` with one path (`SKILL.md:91-92`), and its **Process Comments** workflow assumes a single file (`SKILL.md:166-205`) — so a multi-file review session would surface output the skill's parser doesn't anticipate.
+
+Beyond multi-file, there are concrete **factual errors** (the shortcut table maps `Cmd+T` to "Toggle theme" when it is actually **New Tab** — theme toggle is `Cmd+Shift+T`), a **phantom `--bg` flag** plumbed through the command wrapper that the binary doesn't implement, and entire undocumented surfaces: **stdin mode**, **`--web`/`--tunnel`/`--port`/`--subdomain`**, the **`~/.file-reviewer.json` config** (including `save_on_quit`, which changes whether edits persist), and the fact that the documented install command (`install:app`) builds a binary that **cannot** run `--web`.
+
+## Detailed Findings
+
+### 1. The binary's real CLI surface (`main.rs`)
+
+Flag parsing in `main.rs:16-91` and the `--help` text in `main.rs:280-318`:
+
+| Flag | Meaning | Source |
+|------|---------|--------|
+| `-h, --help` | Help (also prints config path + contents) | `main.rs:21-24`, `305-317` |
+| `-v, --version` | Version | `main.rs:16-19` |
+| `-s, --silent` | Suppress comment output on close | `main.rs:27` |
+| `-j, --json` | JSON output on close | `main.rs:28` |
+| `-w, --web` | Web server mode (requires `web` feature) | `main.rs:29`, `94-105` |
+| `-o, --open` | Auto-open browser (web) | `main.rs:33` |
+| `-t, --tunnel` | localtunnel for remote access (web) | `main.rs:31` |
+| `--subdomain NAME` | Request a tunnel subdomain | `main.rs:35-38` |
+| `--port PORT` | HTTP port (default **3456**) | `main.rs:41-45` |
+| `[FILE]...` | **One or more** file paths → one tab each | `main.rs:50-56` |
+| `-` / piped stdin | Read content from stdin into a temp file | `main.rs:62-91`, `245-278` |
+
+**The skill documents only `--silent` and `--json`** (`SKILL.md:98`) plus a single positional path.
+
+### 2. Multi-file / tabs — the headline gap
+
+**Binary supports it fully:**
+- All non-flag args are collected as file paths (`main.rs:50-56`) and passed as a `Vec<String>` to `run(file_paths, ...)` (`lib.rs:23`). `current_file` = first path; `initial_files` = all paths (`lib.rs:30-48`).
+- The frontend fetches `getInitialFiles()` and opens a tab per path via `loadFile(path, "append")` (`main.ts:442-447`), rendering a tab strip (`tabs-view.ts:14`).
+- Users can open **more** files after launch via `Cmd+T` / `Cmd+O` (multi-select file picker, `file-picker.ts:16`) or **drag-and-drop** (`main.ts:481`).
+- Tab navigation: `Cmd+W` close, `Cmd+1…9` jump, `Cmd+N`/`Cmd+P` next/prev (`shortcuts.ts:152-198`).
+- On close, `submit_tab_states` pushes every tab's content back to Rust (`lib.rs:314`, frontend `main.ts:1295-1314`); output is **grouped per file** with `## <path>` headers when >1 tab, but stays **flat for a single tab** (backward-compat) (`lib.rs:218-271`). JSON multi-tab → array of `{path, comments}` objects, single-tab → bare comments array (`lib.rs:223-253`).
+
+**Skill is single-file throughout:** launch shows one quoted path (`SKILL.md:91-92`); the example output is the flat single-file form (`SKILL.md:108-117`); **Process Comments** says "Read the file" (singular) and never accounts for `## <path>` grouping or N files each carrying their own markers (`SKILL.md:166-205`).
+
+> Caveat for any future doc: **web mode is single-file only.** `run_web_mode` seeds `initial_files` with just the primary file (`main.rs:163-173`) and `/api/quit` reads only `current_file` (`web_server.rs:279-311`). Multi-file output grouping is **Tauri-native only**.
+
+### 3. Keyboard shortcut table is wrong/stale (`SKILL.md:119-130` vs `shortcuts.ts:8-33`)
+
+| Skill says | Reality | Evidence |
+|------------|---------|----------|
+| `Cmd+T` = **Toggle theme** | `Cmd+T` = **New tab (open file)** | `shortcuts.ts:15`, `lib.rs:65`, `shortcuts.ts:179-183` |
+| (missing) | `Cmd+Shift+T` = **Toggle theme** | `shortcuts.ts:19`, `211-213` |
+| (missing) | `Cmd+W` close tab, `Cmd+1…9` jump, `Cmd+N`/`P` next/prev | `shortcuts.ts:16-18`, `174-198` |
+| (missing) | `Cmd+M` toggle markdown raw/pretty | `shortcuts.ts:20`, `214-215` |
+| (missing) | `Cmd++`/`Cmd+-` zoom, `Cmd+Z`/`Cmd+Shift+Z` undo/redo | `shortcuts.ts:23-24`, `223-235` |
+| (missing) | Preview vim nav (`j/k`, `gg/G`), preview search (`/`, `Cmd+F`, `n/N`) | `shortcuts.ts:28-33` |
+
+Correct in the skill: `Cmd+K` add comment, `Cmd+S` save, `Cmd+Q` quit, `Cmd+/` help, `Cmd+Shift+V` vim, `Cmd+O` open.
+
+### 4. stdin mode — undocumented
+
+`cat file.md | file-review` (auto-detected when stdin isn't a TTY) or `file-review -` reads content into a persistent temp file `file-review-<date>-<hash>.md` (`main.rs:62-91`, `245-278`). Output has a **distinct shape**: `=== File ===` / `=== Content ===` / `=== Review Comments [(content modified)] ===` plus a `modified` boolean (`comments.rs:212-263`). The skill has zero coverage of this; it only ever passes an absolute path.
+
+### 5. Web / tunnel mode — undocumented (and an install trap)
+
+`--web` starts an axum HTTP server mirroring the Tauri commands as REST endpoints (`web_server.rs:105-134`); `--tunnel` wraps it in localtunnel for remote review, `--subdomain`/`--port`/`--open` tune it (`main.rs:143-242`). Comments come back via `POST /api/quit`, printed to stdout the same way as native close (`web_server.rs:279-356`).
+
+**Install trap:** the skill's install path uses `bun run install:app` (`SKILL.md:49`), which builds **without** the `web` feature. Such a binary rejects `--web` with *"Web mode requires the 'web' feature"* (`main.rs:101-105`). The web-capable build is `bun run install:web` → `tauri build --features web` (`package.json:13-16`). (This also matches the project memory: file-review releases use `bun run release`, and CLAUDE.md's release process uses `install:web`.)
+
+### 6. Config file — undocumented
+
+`~/.file-reviewer.json` (`config.rs:44-48`) persists `theme`, `vim_mode`, `font_size`, `markdown_raw`, `save_on_quit`, and `window {width,height}` (`config.rs:11-22`). It's surfaced in `--help` (`main.rs:305-317`) and editable from the in-app shortcuts modal ("Edit Config", `shortcuts.ts:115-123`). **`save_on_quit` matters for the skill's contract:** when true, the file is written on quit, so review markers/edits persist to disk without an explicit `Cmd+S`.
+
+### 7. Phantom `--bg` flag in the command wrapper
+
+`commands/file-review.md` advertises `--bg` in its `argument-hint` and instructs "Pass through any arguments and flags (`--bg`, `--silent`, `--json`)" (`file-review.md:2,14`). But the binary has **no** `--bg` flag (`main.rs`), and `SKILL.md:95` explicitly says "Do **NOT** use `--bg`". It's a dead/contradictory flag — backgrounding is handled by the Bash tool's `run_in_background`, not a binary flag.
+
+### 8. Comment marker format — accurate (minor cosmetic drift)
+
+The skill's marker formats and extraction regexes (`SKILL.md:137-162`) match the binary (`comments.rs:72-148`, `270-345`). One cosmetic mismatch: the skill's example output renders the arrow as ASCII `->` (`SKILL.md:114`), but the binary emits the Unicode `→` (`comments.rs:175`, `258`). IDs are the first 8 chars of a UUID v4 (`comments.rs:359`), consistent with the skill's "8-character alphanumeric".
+
+## Gap Summary Table
+
+| Capability | Binary | Skill | Severity |
+|------------|--------|-------|----------|
+| Multiple file paths → tabs | ✅ `main.rs:50-56`, `lib.rs:30-48` | ❌ single path only | **High** |
+| Per-file `## <path>` grouped output | ✅ `lib.rs:218-271` | ❌ not parsed | **High** |
+| Multi-file Process Comments | n/a (output gives it) | ❌ single-file assumption | **High** |
+| Shortcut table correctness | ✅ `shortcuts.ts:8-33` | ❌ `Cmd+T` wrong + many missing | **High** |
+| stdin piping (`cat … \| file-review`, `-`) | ✅ `main.rs:62-91` | ❌ absent | Medium |
+| Web/tunnel mode (`--web`/`-t`/`--port`…) | ✅ `web_server.rs`, `main.rs:143-242` | ❌ absent | Medium |
+| `install:web` needed for web mode | ✅ `package.json:13-16` | ❌ documents `install:app` only | Medium |
+| Config `~/.file-reviewer.json` (+`save_on_quit`) | ✅ `config.rs` | ❌ absent | Medium |
+| Phantom `--bg` flag | ❌ no such flag | ⚠️ advertised in command wrapper | Low |
+| `→` vs `->` in example output | `→` (`comments.rs:175`) | `->` | Cosmetic |
+
+## Proposed Changes / Restructure
+
+The current three-skill layout is sound — `install` and `process-review` are thin redirects into one canonical `SKILL.md` with an intent router (`SKILL.md:12-27`). **Keep that shape**; the fixes are about content accuracy and one new reference section, not architecture.
+
+**A. Correctness fixes (do first, low risk):**
+1. Rewrite the **Keyboard Shortcuts** table from `shortcuts.ts` (fix `Cmd+T`→New Tab, add `Cmd+Shift+T` theme, `Cmd+W`, `Cmd+1…9`, `Cmd+N/P`, `Cmd+M`, zoom, undo/redo, preview nav/search).
+2. Remove the **phantom `--bg`** from `commands/file-review.md` (`argument-hint` and the pass-through instruction) to match `SKILL.md:95`.
+3. Fix the example arrow `->` → `→`.
+
+**B. Add multi-file support (the core ask):**
+4. In **Review a File**, document launching `file-review <path1> <path2> …` (one tab per path) and that more files open via `Cmd+T`/`Cmd+O`/drag-drop. Add a short "Tabs" note to the shortcuts/UX section.
+5. Make **Process Comments multi-file aware**: when >1 file is reviewed, the close output is grouped under `## <path>` headers (`lib.rs:218-271`); each file on disk still holds its own markers. **Consume the grouped close-output as the source of truth** (it carries per-file path, line numbers, and content); **re-read a file from disk only when needed** — e.g. `--silent` suppressed the output or it was truncated. The workflow iterates files: parse the grouped output per `## <path>` section, resolve each comment, then strip markers from the file on disk. Keep the single-file flat-output path as the default for one tab. _(Decided 2026-06-26.)_
+
+**C. New "Binary / CLI Reference" subsection** (single source of truth, mirrors `--help`):
+6. Full flag table (Section 1 above), stdin usage, and the default output formats (native flat, native multi-tab `## path`, JSON shapes, stdin `=== File ===` block).
+
+**D. Advanced / optional surfaces:**
+7. Document **web/tunnel mode** under an "Advanced" heading, **explicitly single-file** (decided — no multi-file web), and requiring the **`install:web`** build. Update the **Install** section so anyone wanting `--web` builds with `bun run install:web` (and align with `bun run release` per project memory). **Homebrew ships native-only** (decided assumption), so the web section must add a caveat: `brew install` users who want `--web` must build from source with `bun run install:web`.
+8. Document the **`~/.file-reviewer.json` config**, especially `save_on_quit` (affects whether edits persist) and that `--help` / the in-app modal expose it.
+
+**E. Optional restructure if `SKILL.md` grows too large:** split the new CLI Reference into a fourth thin skill (e.g. `cli-reference`) that the router points to, mirroring the existing redirect pattern — only if length becomes a problem; otherwise an inline subsection is simpler.
+
+## Code References
+
+| File | Line | Description |
+|------|------|-------------|
+| `file-review/src-tauri/src/main.rs` | 16-91 | CLI flag parsing + multi-file/stdin extraction |
+| `file-review/src-tauri/src/main.rs` | 101-105 | `--web` rejected without `web` feature |
+| `file-review/src-tauri/src/main.rs` | 143-242 | Web/tunnel run path |
+| `file-review/src-tauri/src/main.rs` | 280-318 | `--help` text (source of truth for flags + config) |
+| `file-review/src-tauri/src/lib.rs` | 23-48 | `run(file_paths: Vec<String>)`, seeds tabs from all paths |
+| `file-review/src-tauri/src/lib.rs` | 218-271 | Multi-tab `## <path>` grouped output; single-tab flat fallback |
+| `file-review/src-tauri/src/comments.rs` | 151-179 | `format_comments_readable` (`=== Review Comments (N) ===`, `→`) |
+| `file-review/src-tauri/src/comments.rs` | 212-263 | stdin-mode output (`=== File ===` / `=== Content ===` / modified) |
+| `file-review/src-tauri/src/config.rs` | 11-22, 44-48 | `~/.file-reviewer.json` schema + path |
+| `file-review/src-tauri/src/web_server.rs` | 279-356 | `/api/quit` → comment output + shutdown |
+| `file-review/src/shortcuts.ts` | 8-33, 152-237 | Canonical keyboard map + handlers |
+| `file-review/package.json` | 13-16 | `install:app` (no web) vs `install:web` (`--features web`) |
+| `cc-plugin/file-review/skills/file-review/SKILL.md` | 91-130, 166-205 | Single-file launch, stale shortcuts, single-file Process Comments |
+| `cc-plugin/file-review/commands/file-review.md` | 2, 14 | Phantom `--bg` flag |
+| `cc-plugin/file-review/.claude-plugin/plugin.json` | 4 | Plugin version `1.5.0` |
+
+## Resolved Decisions
+
+_(Resolved by Taras during file-review of this doc, 2026-06-26.)_
+
+- **Homebrew build**: Assume the Homebrew formula ships **only the native binary** (no `web` feature). Therefore the web/tunnel docs must tell `brew install` users to **build from source with `bun run install:web`** if they want `--web`. (Formula lives in `desplega-ai/homebrew-tap`, outside this repo — no need to verify before writing the caveat.)
+- **Multi-file Process Comments source of truth**: **Consume the grouped close-output directly** (it already carries per-file paths, line numbers, and content). **Re-read a file from disk only if needed** — e.g. `--silent` was used or the output was truncated/incomplete.
+- **Web mode multi-file**: **No.** Keep the skill's web section **explicitly single-file**; do not pursue making web mode multi-file.
+
+## Appendix
+
+- **Architecture notes**: The plugin uses a router skill (`SKILL.md`) with two thin redirect skills (`install`, `process-review`) and two backward-compat slash commands (`file-review`, `process-comments`). Output-on-close is the integration contract: the binary prints comments to stdout, the Bash `run_in_background` launch captures it, and the skill parses it. The binary deliberately keeps **single-tab output flat** for backward-compat with shell consumers (`lib.rs:222`).
+- **Historical context (from thoughts/)**:
+  - `thoughts/taras/research/2026-01-15-file-review-web-mode-research.md` — prior research on web mode (the `--web`/`--tunnel` work the skill never absorbed).
+  - `thoughts/taras/research/2026-01-13-file-review-tool-implementation-plan.md` — original tool implementation plan.
+  - `thoughts/taras/research/2026-01-14-skill-wrapper-refactoring.md` — the skill-wrapper/redirect pattern this plugin follows.
+- **Version drift**: `SKILL.md` last edited 2026-03-12 (`6638c33`); multi-file landed 2026-05-05 (`c06b8f8` TabManager, `8d9b943` open/switch/close, `ee17bf6` multi-file export); web mode `ba8c06c`. Plugin manifest `1.5.0`; binary `package.json` `1.10.0`.
+- **Related research**:
+  - `thoughts/taras/research/2026-01-15-file-review-web-mode-research.md` — web/tunnel mode details.


### PR DESCRIPTION
## Summary

Reconciles the marketplace-shipped file-review **plugin skill** (`cc-plugin/file-review/`) with what the **binary** (`file-review/`) actually does. The skill predated multi-file/tabs and web mode — it documented a single-file tool, had a wrong shortcut table, and advertised a non-existent `--bg` flag. Fixed against the binary as source of truth, porting a tightened version of the multi-file/batch behavior from the diverged personal copy.

## Changes

- **Correctness fixes:** shortcut table rebuilt from `src/shortcuts.ts` (`Cmd+T` is *New tab*, not theme; added `Cmd+Shift+T`, `Cmd+W`, `Cmd+1…9`, `Cmd+N/P`, `Cmd+M`, zoom, undo/redo, `Cmd+/`); removed phantom `--bg`; fixed example arrow `->` → `→`.
- **Multi-file + CLI reference:** documents `file-review "<p1>" "<p2>" …` → one tab per path; new Binary/CLI Reference mirroring `--help` (all flags, default port 3456, stdin, output formats).
- **Batch-aware Process Comments:** consumes the grouped close-output as source of truth (re-reads disk only when needed), groups Apply/Acknowledge/Skip per file, emits per-file + totals; pending-batch discovery for the no-path flow.
- **Web/config/install docs:** Advanced (web/tunnel, single-file, `install:web` + Homebrew-native-only caveat) and Config (`~/.file-reviewer.json`) subsections; distinguishes `install:app` vs `install:web`.
- **Version bump:** plugin `1.5.0` → `1.6.0`; description now mentions multi-file.
- **CLAUDE.md:** added an `<important if>` note to keep the binary and skill in sync going forward (this drift is what prompted the work).

## Verification

Each phase's automated grep assertions + automated-QA cross-checks against binary source passed: shortcut table vs `shortcuts.ts`, flag table vs `main.rs` `print_help` (bidirectional, no invented flags), config keys vs `config.rs` `AppConfig` (exact match), and a Process-Comments fixture dry-run resolving all 4 markers across 2 files. `file-review --help` confirmed live against the doc.

### Manual checks (interactive — not run in CI)
- [ ] GUI: `Cmd+T` opens a tab/picker (not a theme flip).
- [ ] `file-review /tmp/a.md /tmp/b.md`, comment in each, close → grouped stdout under `## <path>`, then Process Comments strips markers from both.

## Notes

- No changes to the Rust/TS binary — docs/skill only.
- Personal copy under `~/.agents/` left untouched; Taras will reinstall fresh via `npx skills`.

Plan + research: `thoughts/taras/{plans,research}/2026-06-26-file-review-skill-*.md`.