### PR TITLE
feat(shot): no-auth URL screenshot service (Playwright over CDP, Dockerized)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Monorepo of AI and developer tools by desplega.ai. Each subdirectory is a standa
 | `hive/` | macOS app for Claude Code sessions | TypeScript, Electron, Vite |
 | `hn-sql/` | HN data with Parquet + SQL | - |
 | `invoice-cli/` | Invoice email fetcher | - |
+| `shot/` | No-auth URL screenshot service (Playwright over CDP) | TypeScript, Node, Docker |
 | `thoughts/` | Research notes & plans (via /desplega:*) | Markdown |
 | `willitfront.page/` | HN analysis with natural language | - |
 | `wts/` | Git worktree manager | TypeScript, Bun |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Monorepo of AI and developer tools by [desplega.ai](https://desplega.ai). Each s
 | [hn-sql](./hn-sql) | HN data with Parquet + SQL | - |
 | [invoice-cli](./invoice-cli) | Invoice email fetcher | - |
 | [meme-gen](./meme-gen) | Meme generator using Imgflip API | TypeScript, Bun |
+| [shot](./shot) | No-auth URL screenshot service (Playwright + CDP) | TypeScript, Node, Docker |
 | [thoughts](./thoughts) | Research notes & plans (via /desplega:\*) | Markdown |
 | [willitfront.page](./willitfront.page) | HN analysis with natural language | - |
 | [wts](./wts) | Git worktree manager | TypeScript, Bun |

--- a/shot/.dockerignore
+++ b/shot/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+.env
+*.png
+*.jpg
+*.jpeg
+README.md

--- a/shot/.env.example
+++ b/shot/.env.example
@@ -25,6 +25,8 @@ MAX_HEIGHT=3840
 MAX_DELAY_MS=15000
 MAX_DEVICE_SCALE_FACTOR=3
 MAX_CONCURRENCY=4
+# Max requests allowed to wait for a render slot before returning 503
+MAX_QUEUE=64
 
 # SSRF guard: false (default) refuses private/loopback/metadata targets.
 # Set true ONLY on trusted internal networks.

--- a/shot/.env.example
+++ b/shot/.env.example
@@ -1,0 +1,31 @@
+# Copy to .env (or set in your environment / compose) — all optional.
+
+# HTTP listen port / interface
+PORT=8080
+HOST=0.0.0.0
+
+# Reuse an external CDP endpoint (Chrome pool / browserless) instead of the
+# bundled Chromium.
+# CDP_URL=http://127.0.0.1:9222
+
+# Default viewport
+DEFAULT_WIDTH=1280
+DEFAULT_HEIGHT=800
+
+# Timeouts (ms)
+DEFAULT_TIMEOUT_MS=30000
+MAX_TIMEOUT_MS=60000
+
+# Navigation wait condition: load | domcontentloaded | networkidle | commit
+NAV_WAIT_UNTIL=load
+
+# Resource ceilings
+MAX_WIDTH=3840
+MAX_HEIGHT=3840
+MAX_DELAY_MS=15000
+MAX_DEVICE_SCALE_FACTOR=3
+MAX_CONCURRENCY=4
+
+# SSRF guard: false (default) refuses private/loopback/metadata targets.
+# Set true ONLY on trusted internal networks.
+ALLOW_PRIVATE_IPS=false

--- a/shot/.gitignore
+++ b/shot/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+*.log
+.env
+# local test output
+*.png
+*.jpg
+*.jpeg

--- a/shot/DEPLOY.md
+++ b/shot/DEPLOY.md
@@ -1,0 +1,173 @@
+# Deploying `shot`
+
+`shot` is a single Docker image (`Dockerfile` at `shot/`). Anywhere that runs a
+container works. Below are concrete recipes for a few providers, ordered roughly
+by least → most effort, plus the cross-cutting things that actually bite you
+(memory, `/dev/shm`, and the fact that there's **no auth**).
+
+> **Read this first — there is no authentication.** Anyone who can reach the port
+> can screenshot any URL your network can reach. Always put `shot` behind one of:
+> a private network, a reverse proxy that adds auth (basic auth / API key /
+> mTLS), or an API gateway. The built-in SSRF guard (refuses private/loopback/
+> metadata targets) is on by default but is **not** a substitute for auth. See
+> [Security notes in the README](./README.md#security-notes).
+
+## Sizing & requirements (applies everywhere)
+
+| Resource     | Recommendation                                                        |
+| ------------ | --------------------------------------------------------------------- |
+| Memory       | **≥ 1 GB**, 2 GB comfortable. Chromium is the memory hog.             |
+| CPU          | 1 vCPU works; 2 vCPU for parallel renders.                            |
+| `/dev/shm`   | Give it **1 GB** if you can. The image already passes `--disable-dev-shm-usage`, so it survives the tiny default, but more shm = fewer crashes on heavy pages. |
+| Port         | `8080` (override with `PORT`).                                        |
+| Health check | `GET /health` → `200` when the browser backend is reachable.         |
+| Image size   | ~2.8 GB (Playwright base + Chromium). First push is slow; layers cache after. |
+
+Tune behaviour with the env vars in the [README config table](./README.md#configuration)
+— most useful in prod: `MAX_CONCURRENCY`, `MAX_TIMEOUT_MS`, `ALLOW_PRIVATE_IPS`.
+
+---
+
+## Fly.io — recommended for this workload
+
+Good fit: persistent container, cheap, global regions, real `/dev/shm`.
+
+```bash
+cd shot
+fly launch --no-deploy        # generates fly.toml; pick an app name + region
+```
+
+Then set `fly.toml` to something like:
+
+```toml
+app = "shot"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"   # scale to zero when idle
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[http_service.checks]]
+  method = "get"
+  path = "/health"
+  interval = "30s"
+  timeout = "5s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"                 # bump to 2gb for heavy pages
+```
+
+```bash
+fly deploy
+```
+
+Add auth at the edge with a Fly app secret + a tiny proxy, or run `shot` on the
+private 6PN network and only expose your auth proxy publicly.
+
+---
+
+## Google Cloud Run — serverless, scale-to-zero
+
+Good fit: bursty/low traffic, pay-per-use, managed TLS. Use the **gen2**
+execution environment (Chromium needs the fuller syscall surface).
+
+```bash
+cd shot
+gcloud run deploy shot \
+  --source . \
+  --port 8080 \
+  --memory 2Gi --cpu 2 \
+  --execution-environment gen2 \
+  --health-check-path /health \
+  --no-allow-unauthenticated      # require IAM auth; or front with API Gateway
+```
+
+Notes:
+- Cold starts include booting Chromium (a few seconds). Set `--min-instances 1`
+  if you need it warm.
+- Cloud Run injects `PORT` automatically — the app honours it.
+- `--no-allow-unauthenticated` gives you IAM auth for free; clients send a Google
+  identity token. Use `--allow-unauthenticated` only behind your own gateway.
+
+---
+
+## Railway / Render — easiest "connect a repo" flow
+
+**Railway:** New Project → Deploy from Repo → set **Root Directory** to `shot`
+(it auto-detects the `Dockerfile`). Set the service to ≥ 1 GB RAM. Add a health
+check on `/health`. Railway provides a public URL + TLS — add auth before sharing.
+
+**Render:** New → **Web Service** → Docker → **Root Directory** `shot`,
+**Health Check Path** `/health`, instance type with ≥ 1 GB (Standard). Render
+terminates TLS for you.
+
+Neither adds auth — gate it (Render: a proxy/IP allowlist; Railway: a front
+service) before exposing.
+
+---
+
+## Dokploy on a Hetzner VPS — desplega's own stack
+
+1. Provision a Hetzner box with headroom — **CPX21** (2 vCPU / 4 GB) is plenty.
+   (See the `hcloud` skill / `dokcli` in this repo.)
+2. In Dokploy: **Create Application → Docker / Compose**, point it at this repo
+   with build context `shot/` (or paste `shot/docker-compose.yml`).
+3. Expose port `8080`, attach Dokploy's Traefik domain, and **enable Basic Auth /
+   an auth middleware on the route** — that's your authentication layer.
+4. Deploy. Dokploy handles TLS + restarts.
+
+---
+
+## Any Docker host / docker compose (VPS, homelab, bare metal)
+
+```bash
+cd shot
+docker compose up -d --build
+# or without compose:
+docker build -t shot .
+docker run -d --name shot --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 --shm-size=1g shot
+```
+
+Binding to `127.0.0.1` keeps it private; put Caddy/Traefik/nginx in front for
+TLS **and** auth (e.g. Caddy `basicauth`, or an API-key check). Example Caddy:
+
+```caddyfile
+shot.example.com {
+  basicauth { admin <bcrypt-hash> }
+  reverse_proxy 127.0.0.1:8080
+}
+```
+
+---
+
+## Other options (same image, no special steps)
+
+- **AWS** — ECS Fargate (1 vCPU / 2 GB task) or App Runner. Front with ALB +
+  Cognito / WAF for auth.
+- **DigitalOcean** — App Platform (Dockerfile, ≥ 1 GB instance) or a Droplet with
+  the docker-compose recipe above.
+- **Kubernetes** — `Deployment` + `Service`; set `resources.requests.memory: 1Gi`,
+  mount an `emptyDir` with `medium: Memory` at `/dev/shm` for extra headroom, and
+  use `/health` for both liveness and readiness probes.
+
+---
+
+## Post-deploy smoke test
+
+```bash
+BASE=https://your-deployment.example.com   # include creds if behind basic auth
+
+curl -fsS "$BASE/health"
+curl -fsS "$BASE/screenshot?url=https://example.com" -o shot.png && file shot.png
+```
+
+`/health` should return `{"status":"ok","browserConnected":true,...}` and the
+screenshot should be a valid PNG.

--- a/shot/Dockerfile
+++ b/shot/Dockerfile
@@ -1,0 +1,27 @@
+# Playwright's official image ships Chromium + all OS deps, matched to the
+# pinned playwright npm version (keep this tag in sync with package.json).
+FROM mcr.microsoft.com/playwright:v1.61.1-noble
+
+ENV NODE_ENV=production \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    PORT=8080
+
+WORKDIR /app
+
+# Install runtime deps only (tsx + playwright). Browsers are already in the image,
+# so PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD avoids a redundant download.
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+COPY tsconfig.json ./
+COPY src ./src
+COPY scripts ./scripts
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=25s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||8080)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+# Entrypoint supervises two processes: a Chromium CDP server + the screenshot
+# server that connects to it (both restart on failure).
+CMD ["node", "scripts/supervisor.mjs"]

--- a/shot/README.md
+++ b/shot/README.md
@@ -108,6 +108,7 @@ All via environment variables (see [`.env.example`](./.env.example)):
 | `MAX_TIMEOUT_MS`          | `60000`     | Ceiling for `timeout`                                |
 | `NAV_WAIT_UNTIL`          | `load`      | Default wait condition                               |
 | `MAX_CONCURRENCY`         | `4`         | Max simultaneous renders (rest queue)                |
+| `MAX_QUEUE`               | `64`        | Max requests waiting for a slot before shedding load (`503`) |
 | `MAX_WIDTH/HEIGHT`        | `3840`      | Viewport ceilings                                    |
 | `MAX_DEVICE_SCALE_FACTOR` | `3`         | DPR ceiling                                          |
 | `MAX_DELAY_MS`            | `15000`     | Ceiling for `delay`                                  |
@@ -123,7 +124,11 @@ All via environment variables (see [`.env.example`](./.env.example)):
   This is a guard rail, not airtight — it does not stop DNS rebinding or
   redirects to private hosts mid-navigation.
 - Resource ceilings (`MAX_*`) bound viewport size, DPR, delay, timeout, and
-  concurrency so a single caller can't trivially exhaust memory.
+  concurrency so a single caller can't trivially exhaust memory. Beyond
+  `MAX_CONCURRENCY` renders, up to `MAX_QUEUE` requests wait; further ones are
+  shed with `503` + `Retry-After` instead of piling up unbounded.
+- The `CDP_URL` (which may embed a backend credential) is **redacted** to
+  scheme+host in the public `/` and `/health` responses — never echoed raw.
 
 ## Deployment
 

--- a/shot/README.md
+++ b/shot/README.md
@@ -1,0 +1,169 @@
+# shot
+
+A tiny, no-auth **screenshot service**. Give it a URL, get back a PNG (or JPEG).
+Renders with **Playwright over CDP** — bundled Chromium by default, or any external
+CDP backend you point it at.
+
+```
+GET /                       → help JSON (routes + examples)
+GET /health                 → liveness + browser status
+GET /screenshot?url=<URL>   → image/png (or jpeg)
+GET /openapi.json           → OpenAPI 3.1 spec
+```
+
+## Quick start
+
+### Docker (recommended)
+
+```bash
+cd shot
+docker compose up --build
+# or:
+docker build -t shot .
+docker run --rm -p 8080:8080 --shm-size=1g shot
+```
+
+Then:
+
+```bash
+curl 'http://localhost:8080/screenshot?url=https://example.com' -o shot.png
+open shot.png
+```
+
+### Local dev
+
+Requires Node 18+.
+
+```bash
+cd shot
+npm install
+npx playwright install chromium   # one-time: download the browser
+npm run dev                        # single process: app launches its own Chromium
+```
+
+To exercise the container's two-process model locally (Chromium CDP server +
+app, supervised):
+
+```bash
+npm run start:supervised
+# If port 9222 is already in use (e.g. another Chrome with remote debugging):
+CDP_PORT=9333 npm run start:supervised
+```
+
+## Endpoints
+
+### `GET /screenshot`
+
+| Param        | Type                                              | Default | Notes                                   |
+| ------------ | ------------------------------------------------- | ------- | --------------------------------------- |
+| `url`        | string (**required**)                             | —       | Absolute http(s) URL                    |
+| `full_page`  | bool                                              | `false` | Capture full scrollable page            |
+| `width`      | int                                               | `1280`  | Viewport width (CSS px)                 |
+| `height`     | int                                               | `800`   | Viewport height (CSS px)                |
+| `format`     | `png` \| `jpeg`                                   | `png`   |                                         |
+| `quality`    | int 0–100                                         | `80`    | JPEG only                               |
+| `scale`      | number                                            | `1`     | Device scale factor (DPR)               |
+| `wait_until` | `load` \| `domcontentloaded` \| `networkidle` \| `commit` | `load`  | Playwright navigation condition |
+| `delay`      | int ms                                            | `0`     | Extra wait after load                   |
+| `timeout`    | int ms                                            | `30000` | Navigation timeout (capped by `MAX_TIMEOUT_MS`) |
+| `dark`       | bool                                              | `false` | Emulate `prefers-color-scheme: dark`    |
+
+Examples:
+
+```bash
+# viewport shot
+curl 'http://localhost:8080/screenshot?url=https://example.com' -o a.png
+
+# full page, retina, dark mode
+curl 'http://localhost:8080/screenshot?url=https://news.ycombinator.com&full_page=true&scale=2&dark=true' -o b.png
+
+# jpeg at 1080p
+curl 'http://localhost:8080/screenshot?url=https://example.com&width=1920&height=1080&format=jpeg&quality=70' -o c.jpg
+```
+
+### `GET /health`
+
+```json
+{ "status": "ok", "backend": "chromium:bundled", "browserConnected": true, "uptimeSeconds": 12, "version": "0.1.0" }
+```
+
+Returns `503` if the browser backend is unreachable.
+
+### `GET /` and `GET /openapi.json`
+
+`/` returns a self-describing help document; `/openapi.json` returns the OpenAPI 3.1 spec.
+
+## Configuration
+
+All via environment variables (see [`.env.example`](./.env.example)):
+
+| Var                       | Default     | Meaning                                              |
+| ------------------------- | ----------- | ---------------------------------------------------- |
+| `PORT` / `HOST`           | `8080` / `0.0.0.0` | Listen address                                |
+| `CDP_URL`                 | _(unset)_   | Reuse an external CDP backend instead of launching Chromium |
+| `CDP_PORT` / `CDP_BIND`   | `9222` / `127.0.0.1` | Port/bind for the supervisor's Chromium CDP server |
+| `CDP_READY_TIMEOUT_MS`    | `30000`     | How long the supervisor waits for the CDP server before starting the app |
+| `DEFAULT_WIDTH/HEIGHT`    | `1280`/`800`| Default viewport                                     |
+| `DEFAULT_TIMEOUT_MS`      | `30000`     | Default navigation timeout                            |
+| `MAX_TIMEOUT_MS`          | `60000`     | Ceiling for `timeout`                                |
+| `NAV_WAIT_UNTIL`          | `load`      | Default wait condition                               |
+| `MAX_CONCURRENCY`         | `4`         | Max simultaneous renders (rest queue)                |
+| `MAX_WIDTH/HEIGHT`        | `3840`      | Viewport ceilings                                    |
+| `MAX_DEVICE_SCALE_FACTOR` | `3`         | DPR ceiling                                          |
+| `MAX_DELAY_MS`            | `15000`     | Ceiling for `delay`                                  |
+| `ALLOW_PRIVATE_IPS`       | `false`     | Allow private/loopback targets (disables SSRF guard) |
+
+## Security notes
+
+- **No authentication** — as requested. Put it behind a reverse proxy / network
+  policy if exposed beyond a trusted boundary.
+- **SSRF guard (on by default):** requests whose URL resolves to a private,
+  loopback, link-local, or cloud-metadata address (e.g. `169.254.169.254`) are
+  refused with `403`. Set `ALLOW_PRIVATE_IPS=true` to screenshot intranet hosts.
+  This is a guard rail, not airtight — it does not stop DNS rebinding or
+  redirects to private hosts mid-navigation.
+- Resource ceilings (`MAX_*`) bound viewport size, DPR, delay, timeout, and
+  concurrency so a single caller can't trivially exhaust memory.
+
+## Deployment
+
+It's one Docker image — runs anywhere containers do. See **[DEPLOY.md](./DEPLOY.md)**
+for provider-specific recipes (Fly.io, Cloud Run, Railway/Render, Dokploy on
+Hetzner, plain docker compose) plus sizing and the "put it behind auth" checklist.
+
+## Architecture
+
+In the container, the entrypoint (`scripts/supervisor.mjs`) runs **two supervised
+processes**, restarting either on failure:
+
+```
+                       ┌─────────────────────────────┐
+ docker CMD ──▶ supervisor.mjs                        │
+                       │  ├─ chromium-cdp  (CDP server on 127.0.0.1:9222)
+                       │  └─ shot-server   (HTTP :8080, connectOverCDP → 9222)
+                       └─────────────────────────────┘
+```
+
+This is the "reuse CDP servers" shape: the browser is a separate, long-lived CDP
+server that the app attaches to. Set `CDP_URL` to point at an **external** CDP
+backend (Chrome pool, browserless) and the supervisor skips launching Chromium and
+just supervises the app against it.
+
+Running `npm start` directly (local dev) is single-process: the app launches its
+own Chromium via Playwright instead.
+
+```
+src/
+  server.ts        HTTP routing, param parsing, error → JSON
+  browser.ts       shared browser (launch or connectOverCDP) + render + concurrency
+  ssrf.ts          private-address guard
+  openapi.ts       OpenAPI 3.1 document
+  config.ts        env-driven config
+  errors.ts        HttpError
+scripts/
+  supervisor.mjs   2-process container entrypoint (CDP browser + app, restart-on-fail)
+```
+
+One browser is kept alive per process and reused; every request gets its own
+isolated `BrowserContext` + `Page`, closed when the response is sent. If the CDP
+backend drops, the app transparently reconnects on the next request.

--- a/shot/docker-compose.yml
+++ b/shot/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  shot:
+    build: .
+    image: desplega/shot:latest
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+      # SSRF guard is on by default; flip to "true" only on trusted/internal nets.
+      # ALLOW_PRIVATE_IPS: "false"
+      # MAX_CONCURRENCY: "4"
+      #
+      # The entrypoint supervises two processes: a Chromium CDP server +
+      # the screenshot server connected to it (both restart on failure).
+      #
+      # Set CDP_URL to reuse an EXTERNAL CDP backend (Chrome pool / browserless)
+      # instead — the entrypoint then skips launching Chromium and just supervises
+      # the server against it:
+      # CDP_URL: "http://chrome:9222"
+    # Chromium is unhappy with the tiny default /dev/shm in containers.
+    shm_size: "1gb"
+    restart: unless-stopped

--- a/shot/package-lock.json
+++ b/shot/package-lock.json
@@ -1,0 +1,584 @@
+{
+  "name": "@desplega.ai/shot",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@desplega.ai/shot",
+      "version": "0.1.0",
+      "dependencies": {
+        "playwright": "1.61.1",
+        "tsx": "^4.19.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/shot/package.json
+++ b/shot/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@desplega.ai/shot",
+  "version": "0.1.0",
+  "private": true,
+  "description": "No-auth screenshot service: render any URL to PNG/JPEG via Playwright over CDP (bundled Chromium, or reuse an external CDP backend).",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "tsx src/server.ts",
+    "start:supervised": "node scripts/supervisor.mjs",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "playwright": "1.61.1",
+    "tsx": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.2"
+  }
+}

--- a/shot/scripts/supervisor.mjs
+++ b/shot/scripts/supervisor.mjs
@@ -1,0 +1,123 @@
+// Container entrypoint: run two supervised processes and restart either on
+// failure.
+//
+//   1. chromium-cdp — a long-lived Chromium exposing a CDP server on
+//      127.0.0.1:$CDP_PORT (the rendering backend; the reusable "cdp server").
+//   2. shot-server  — the Playwright screenshot HTTP server, pointed at that CDP
+//      endpoint via CDP_URL (so it connectOverCDP instead of launching its own).
+//
+// Both run under a tiny supervisor: crash → restart with capped exponential
+// backoff. SIGTERM/SIGINT are forwarded to children for clean shutdown.
+
+import { spawn } from "node:child_process";
+import { chromium } from "playwright";
+
+// If CDP_URL is already set, reuse that external CDP backend (e.g. a Chrome pool
+// or browserless) and don't launch our own Chromium.
+const EXTERNAL_CDP = process.env.CDP_URL?.trim();
+const CDP_PORT = process.env.CDP_PORT ?? "9222";
+const CDP_BIND = process.env.CDP_BIND ?? "127.0.0.1";
+const INTERNAL_CDP_URL = `http://127.0.0.1:${CDP_PORT}`;
+const READY_TIMEOUT_MS = Number(process.env.CDP_READY_TIMEOUT_MS ?? 30_000);
+
+const CHROMIUM_ARGS = [
+  "--headless=new",
+  "--no-sandbox",
+  "--disable-dev-shm-usage",
+  "--disable-gpu",
+  "--hide-scrollbars",
+  "--mute-audio",
+  "--no-first-run",
+  "--no-default-browser-check",
+  "--disable-background-networking",
+  `--remote-debugging-address=${CDP_BIND}`,
+  `--remote-debugging-port=${CDP_PORT}`,
+  "--user-data-dir=/tmp/shot-chrome",
+  "about:blank",
+];
+
+const children = new Set();
+let shuttingDown = false;
+
+function log(msg) {
+  console.log(`[supervisor] ${msg}`);
+}
+
+/** Spawn `name` and keep it alive (restart on exit with backoff). */
+function supervise(name, command, args, env = {}) {
+  let restarts = 0;
+  const start = () => {
+    if (shuttingDown) return;
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      env: { ...process.env, ...env },
+    });
+    children.add(child);
+    child.on("exit", (code, signal) => {
+      children.delete(child);
+      if (shuttingDown) return;
+      restarts += 1;
+      const delay = Math.min(10_000, 250 * 2 ** Math.min(restarts, 6));
+      log(`${name} exited (code=${code} signal=${signal}); restart #${restarts} in ${delay}ms`);
+      setTimeout(start, delay);
+    });
+    child.on("error", (err) => {
+      log(`${name} spawn error: ${err.message}`);
+    });
+  };
+  start();
+}
+
+/** Poll the CDP server's version endpoint until it answers (or time out). */
+async function waitForCdp(cdpUrl) {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (shuttingDown) return;
+    try {
+      const res = await fetch(`${cdpUrl}/json/version`);
+      if (res.ok) {
+        log(`CDP server ready at ${cdpUrl}`);
+        return;
+      }
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  log(`CDP server not ready after ${READY_TIMEOUT_MS}ms; starting shot-server anyway (it will retry)`);
+}
+
+function shutdown(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  log(`received ${signal}, terminating children…`);
+  for (const child of children) child.kill("SIGTERM");
+  // Hard exit if children linger.
+  setTimeout(() => process.exit(0), 5_000).unref();
+  // Exit once all children are gone.
+  const check = setInterval(() => {
+    if (children.size === 0) {
+      clearInterval(check);
+      process.exit(0);
+    }
+  }, 100);
+}
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
+// --- boot -------------------------------------------------------------------
+
+const SERVER_ARGS = ["--import", "tsx", "src/server.ts"];
+
+if (EXTERNAL_CDP) {
+  log(`reusing external CDP backend at ${EXTERNAL_CDP}; not launching Chromium`);
+  await waitForCdp(EXTERNAL_CDP);
+  // CDP_URL is already in the environment, inherited by the child.
+  supervise("shot-server", process.execPath, SERVER_ARGS);
+} else {
+  const chromiumPath = chromium.executablePath();
+  log(`chromium: ${chromiumPath}`);
+  supervise("chromium-cdp", chromiumPath, CHROMIUM_ARGS);
+  await waitForCdp(INTERNAL_CDP_URL);
+  supervise("shot-server", process.execPath, SERVER_ARGS, { CDP_URL: INTERNAL_CDP_URL });
+}

--- a/shot/src/browser.ts
+++ b/shot/src/browser.ts
@@ -9,17 +9,31 @@
 
 import { chromium, type Browser, type BrowserContext } from "playwright";
 import { config } from "./config";
+import { HttpError } from "./errors";
 
-/** Minimal FIFO semaphore bounding concurrent renders. */
+/**
+ * Minimal FIFO semaphore bounding concurrent renders, with a bounded wait queue.
+ * Once `max` renders are in flight and `maxQueue` requests are already waiting,
+ * further acquires are rejected (503) instead of piling up unbounded — otherwise
+ * an unauthenticated flood could exhaust memory/file descriptors.
+ */
 class Semaphore {
   private active = 0;
   private readonly queue: Array<() => void> = [];
-  constructor(private readonly max: number) {}
+  constructor(
+    private readonly max: number,
+    private readonly maxQueue: number,
+  ) {}
 
   acquire(): Promise<void> {
     if (this.active < this.max) {
       this.active++;
       return Promise.resolve();
+    }
+    if (this.queue.length >= this.maxQueue) {
+      return Promise.reject(
+        new HttpError(503, "Server busy: render queue full, retry shortly"),
+      );
     }
     return new Promise<void>((resolve) => this.queue.push(resolve));
   }
@@ -41,8 +55,21 @@ const LAUNCH_ARGS = [
 
 let browserPromise: Promise<Browser> | null = null;
 
+/**
+ * A safe label for the rendering backend, exposed on the unauthenticated `/` and
+ * `/health` responses. A CDP URL can embed credentials (userinfo, or a token in
+ * the query string, e.g. browserless), so we strip everything but scheme+host:port
+ * — never the raw value.
+ */
 export function backendDescription(): string {
-  return config.cdpUrl ? `cdp:${config.cdpUrl}` : "chromium:bundled";
+  if (!config.cdpUrl) return "chromium:bundled";
+  try {
+    const u = new URL(config.cdpUrl);
+    const auth = u.username ? "***@" : ""; // signal creds exist without leaking them
+    return `cdp:${u.protocol}//${auth}${u.host}`;
+  } catch {
+    return "cdp:external";
+  }
 }
 
 async function createBrowser(): Promise<Browser> {
@@ -100,7 +127,7 @@ export interface ShotOptions {
 }
 
 // Bound the number of pages rendering at once to keep memory predictable.
-const semaphore = new Semaphore(Math.max(1, config.maxConcurrency));
+const semaphore = new Semaphore(Math.max(1, config.maxConcurrency), Math.max(0, config.maxQueue));
 
 /** Render a URL to an image buffer. */
 export async function takeScreenshot(opts: ShotOptions): Promise<Buffer> {

--- a/shot/src/browser.ts
+++ b/shot/src/browser.ts
@@ -1,0 +1,130 @@
+// Browser lifecycle + screenshot rendering.
+//
+// One shared browser is kept alive for the process and reused across requests;
+// every request gets its own isolated BrowserContext + Page. The browser is
+// either:
+//   - launched locally (bundled Chromium) when CDP_URL is unset — renders pixels;
+//   - or attached to an external CDP endpoint via connectOverCDP(CDP_URL) — lets
+//     you reuse a Chrome pool / browserless server.
+
+import { chromium, type Browser, type BrowserContext } from "playwright";
+import { config } from "./config";
+
+/** Minimal FIFO semaphore bounding concurrent renders. */
+class Semaphore {
+  private active = 0;
+  private readonly queue: Array<() => void> = [];
+  constructor(private readonly max: number) {}
+
+  acquire(): Promise<void> {
+    if (this.active < this.max) {
+      this.active++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => this.queue.push(resolve));
+  }
+
+  release(): void {
+    const next = this.queue.shift();
+    if (next) next(); // hand the slot directly to the next waiter
+    else this.active--;
+  }
+}
+
+const LAUNCH_ARGS = [
+  "--no-sandbox",
+  "--disable-dev-shm-usage",
+  "--disable-gpu",
+  "--hide-scrollbars",
+  "--mute-audio",
+];
+
+let browserPromise: Promise<Browser> | null = null;
+
+export function backendDescription(): string {
+  return config.cdpUrl ? `cdp:${config.cdpUrl}` : "chromium:bundled";
+}
+
+async function createBrowser(): Promise<Browser> {
+  const browser = config.cdpUrl
+    ? await chromium.connectOverCDP(config.cdpUrl)
+    : await chromium.launch({ headless: true, args: LAUNCH_ARGS });
+
+  // If the backend drops (crash, remote restart), force a reconnect next time.
+  browser.on("disconnected", () => {
+    browserPromise = null;
+  });
+  return browser;
+}
+
+/** Lazily create (and transparently re-create) the shared browser. */
+export async function getBrowser(): Promise<Browser> {
+  if (!browserPromise) {
+    browserPromise = createBrowser().catch((err) => {
+      browserPromise = null; // don't cache the failure
+      throw err;
+    });
+  }
+  const browser = await browserPromise;
+  if (!browser.isConnected()) {
+    browserPromise = null;
+    return getBrowser();
+  }
+  return browser;
+}
+
+export async function closeBrowser(): Promise<void> {
+  const pending = browserPromise;
+  browserPromise = null;
+  if (!pending) return;
+  try {
+    const browser = await pending;
+    await browser.close();
+  } catch {
+    // best-effort on shutdown
+  }
+}
+
+export interface ShotOptions {
+  url: string;
+  fullPage: boolean;
+  width: number;
+  height: number;
+  deviceScaleFactor: number;
+  format: "png" | "jpeg";
+  quality: number | undefined;
+  waitUntil: "load" | "domcontentloaded" | "networkidle" | "commit";
+  timeout: number;
+  delay: number;
+  colorScheme: "light" | "dark" | undefined;
+}
+
+// Bound the number of pages rendering at once to keep memory predictable.
+const semaphore = new Semaphore(Math.max(1, config.maxConcurrency));
+
+/** Render a URL to an image buffer. */
+export async function takeScreenshot(opts: ShotOptions): Promise<Buffer> {
+  await semaphore.acquire();
+  let context: BrowserContext | undefined;
+  try {
+    const browser = await getBrowser();
+    context = await browser.newContext({
+      viewport: { width: opts.width, height: opts.height },
+      deviceScaleFactor: opts.deviceScaleFactor,
+      colorScheme: opts.colorScheme,
+      ignoreHTTPSErrors: true,
+    });
+    const page = await context.newPage();
+    page.setDefaultNavigationTimeout(opts.timeout);
+    await page.goto(opts.url, { waitUntil: opts.waitUntil, timeout: opts.timeout });
+    if (opts.delay > 0) await page.waitForTimeout(opts.delay);
+    return await page.screenshot({
+      fullPage: opts.fullPage,
+      type: opts.format,
+      quality: opts.format === "jpeg" ? opts.quality : undefined,
+    });
+  } finally {
+    if (context) await context.close().catch(() => {});
+    semaphore.release();
+  }
+}

--- a/shot/src/config.ts
+++ b/shot/src/config.ts
@@ -55,6 +55,9 @@ export const config = {
   /** Max screenshots rendered concurrently; further requests queue. */
   maxConcurrency: num("MAX_CONCURRENCY", 4),
 
+  /** Max requests allowed to wait for a render slot before we shed load (503). */
+  maxQueue: num("MAX_QUEUE", 64),
+
   /**
    * SSRF guard: when false (default), refuse URLs that resolve to private,
    * loopback, link-local or cloud-metadata addresses. Set ALLOW_PRIVATE_IPS=true

--- a/shot/src/config.ts
+++ b/shot/src/config.ts
@@ -1,0 +1,66 @@
+// Centralised, env-driven configuration. Everything has a sane default so the
+// server runs with zero configuration: `docker run -p 8080:8080 shot`.
+
+function num(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    throw new Error(`Env ${name}="${raw}" is not a number`);
+  }
+  return n;
+}
+
+function bool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  return /^(1|true|yes|on)$/i.test(raw.trim());
+}
+
+function str(name: string, fallback: string): string {
+  const raw = process.env[name];
+  return raw === undefined || raw.trim() === "" ? fallback : raw.trim();
+}
+
+export const config = {
+  /** HTTP port the screenshot service listens on. */
+  port: num("PORT", 8080),
+  /** Interface to bind. 0.0.0.0 so it works inside a container. */
+  host: str("HOST", "0.0.0.0"),
+
+  /**
+   * Optional CDP endpoint to reuse instead of launching a browser (e.g. a Chrome
+   * pool or browserless: `http://chrome:9222`). When unset, the service launches
+   * its own bundled Chromium.
+   */
+  cdpUrl: process.env.CDP_URL?.trim() || undefined,
+
+  /** Default viewport when the request doesn't specify width/height. */
+  defaultWidth: num("DEFAULT_WIDTH", 1280),
+  defaultHeight: num("DEFAULT_HEIGHT", 800),
+
+  /** Navigation/screenshot timeout defaults and ceiling (milliseconds). */
+  defaultTimeoutMs: num("DEFAULT_TIMEOUT_MS", 30_000),
+  maxTimeoutMs: num("MAX_TIMEOUT_MS", 60_000),
+
+  /** Default Playwright `waitUntil` for navigation. */
+  defaultWaitUntil: str("NAV_WAIT_UNTIL", "load"),
+
+  /** Hard ceilings on viewport size and post-load delay to bound resource use. */
+  maxWidth: num("MAX_WIDTH", 3840),
+  maxHeight: num("MAX_HEIGHT", 3840),
+  maxDelayMs: num("MAX_DELAY_MS", 15_000),
+  maxDeviceScaleFactor: num("MAX_DEVICE_SCALE_FACTOR", 3),
+
+  /** Max screenshots rendered concurrently; further requests queue. */
+  maxConcurrency: num("MAX_CONCURRENCY", 4),
+
+  /**
+   * SSRF guard: when false (default), refuse URLs that resolve to private,
+   * loopback, link-local or cloud-metadata addresses. Set ALLOW_PRIVATE_IPS=true
+   * for fully-trusted/internal deployments that need to screenshot intranet hosts.
+   */
+  allowPrivateIps: bool("ALLOW_PRIVATE_IPS", false),
+} as const;
+
+export const VERSION = "0.1.0";

--- a/shot/src/errors.ts
+++ b/shot/src/errors.ts
@@ -1,0 +1,10 @@
+/** An error carrying an HTTP status code, surfaced as a JSON error response. */
+export class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}

--- a/shot/src/openapi.ts
+++ b/shot/src/openapi.ts
@@ -147,6 +147,7 @@ export function openapiSpec(): unknown {
             "400": { description: "Missing or invalid parameters" },
             "403": { description: "Target blocked by SSRF guard" },
             "502": { description: "Failed to render the page" },
+            "503": { description: "Server busy: render queue full (honor Retry-After)" },
           },
         },
       },

--- a/shot/src/openapi.ts
+++ b/shot/src/openapi.ts
@@ -1,0 +1,161 @@
+import { VERSION } from "./config";
+
+/** OpenAPI 3.1 description of the service, served at /openapi.json. */
+export function openapiSpec(): unknown {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "shot",
+      version: VERSION,
+      description:
+        "No-auth screenshot service. Renders a URL to PNG/JPEG using Playwright over CDP. " +
+        "Bundled Chromium renders real pixels; CDP_URL can point at any Chrome/CDP backend.",
+    },
+    paths: {
+      "/": {
+        get: {
+          summary: "Service help",
+          description: "Human/agent-readable JSON describing the routes and example calls.",
+          responses: {
+            "200": {
+              description: "Help document",
+              content: { "application/json": { schema: { type: "object" } } },
+            },
+          },
+        },
+      },
+      "/health": {
+        get: {
+          summary: "Health check",
+          description: "Liveness probe. Reports whether the browser backend is reachable.",
+          responses: {
+            "200": {
+              description: "Service healthy",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: { type: "string", example: "ok" },
+                      backend: { type: "string", example: "chromium:bundled" },
+                      browserConnected: { type: "boolean" },
+                      uptimeSeconds: { type: "number" },
+                    },
+                  },
+                },
+              },
+            },
+            "503": { description: "Browser backend unreachable" },
+          },
+        },
+      },
+      "/screenshot": {
+        get: {
+          summary: "Capture a screenshot",
+          description: "Navigate to `url` and return a PNG (default) or JPEG image of the page.",
+          parameters: [
+            {
+              name: "url",
+              in: "query",
+              required: true,
+              description: "Absolute http(s) URL to capture.",
+              schema: { type: "string", format: "uri", example: "https://example.com" },
+            },
+            {
+              name: "full_page",
+              in: "query",
+              required: false,
+              description: "Capture the full scrollable page instead of just the viewport.",
+              schema: { type: "boolean", default: false },
+            },
+            {
+              name: "width",
+              in: "query",
+              required: false,
+              description: "Viewport width in CSS pixels.",
+              schema: { type: "integer", default: 1280 },
+            },
+            {
+              name: "height",
+              in: "query",
+              required: false,
+              description: "Viewport height in CSS pixels.",
+              schema: { type: "integer", default: 800 },
+            },
+            {
+              name: "format",
+              in: "query",
+              required: false,
+              description: "Output image format.",
+              schema: { type: "string", enum: ["png", "jpeg"], default: "png" },
+            },
+            {
+              name: "quality",
+              in: "query",
+              required: false,
+              description: "JPEG quality 0-100 (ignored for png).",
+              schema: { type: "integer", minimum: 0, maximum: 100, default: 80 },
+            },
+            {
+              name: "scale",
+              in: "query",
+              required: false,
+              description: "Device scale factor (DPR) for retina-density output.",
+              schema: { type: "number", default: 1 },
+            },
+            {
+              name: "wait_until",
+              in: "query",
+              required: false,
+              description: "Playwright navigation wait condition.",
+              schema: {
+                type: "string",
+                enum: ["load", "domcontentloaded", "networkidle", "commit"],
+                default: "load",
+              },
+            },
+            {
+              name: "delay",
+              in: "query",
+              required: false,
+              description: "Extra milliseconds to wait after load before capturing.",
+              schema: { type: "integer", default: 0 },
+            },
+            {
+              name: "timeout",
+              in: "query",
+              required: false,
+              description: "Navigation timeout in milliseconds.",
+              schema: { type: "integer", default: 30000 },
+            },
+            {
+              name: "dark",
+              in: "query",
+              required: false,
+              description: "Emulate prefers-color-scheme: dark.",
+              schema: { type: "boolean", default: false },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "The rendered image",
+              content: {
+                "image/png": { schema: { type: "string", format: "binary" } },
+                "image/jpeg": { schema: { type: "string", format: "binary" } },
+              },
+            },
+            "400": { description: "Missing or invalid parameters" },
+            "403": { description: "Target blocked by SSRF guard" },
+            "502": { description: "Failed to render the page" },
+          },
+        },
+      },
+      "/openapi.json": {
+        get: {
+          summary: "OpenAPI document",
+          responses: { "200": { description: "This document" } },
+        },
+      },
+    },
+  };
+}

--- a/shot/src/server.ts
+++ b/shot/src/server.ts
@@ -1,0 +1,246 @@
+import http from "node:http";
+import { config, VERSION } from "./config";
+import { HttpError } from "./errors";
+import { assertUrlAllowed } from "./ssrf";
+import {
+  backendDescription,
+  closeBrowser,
+  getBrowser,
+  takeScreenshot,
+  type ShotOptions,
+} from "./browser";
+import { openapiSpec } from "./openapi";
+
+const startedAt = Date.now();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body, null, 2);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+function sendError(res: http.ServerResponse, status: number, message: string): void {
+  sendJson(res, status, { error: { status, message } });
+}
+
+const WAIT_UNTIL = new Set(["load", "domcontentloaded", "networkidle", "commit"]);
+
+/** Turn the query string into validated, clamped screenshot options. */
+function parseShotOptions(params: URLSearchParams, url: string): ShotOptions {
+  const intParam = (name: string, fallback: number): number => {
+    const raw = params.get(name);
+    if (raw === null) return fallback;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) throw new HttpError(400, `Parameter "${name}" must be a number`);
+    return Math.trunc(n);
+  };
+  const boolParam = (name: string): boolean => {
+    const raw = params.get(name);
+    return raw !== null && /^(1|true|yes|on|)$/i.test(raw);
+  };
+
+  const format = (params.get("format") ?? "png").toLowerCase();
+  if (format !== "png" && format !== "jpeg" && format !== "jpg") {
+    throw new HttpError(400, `Parameter "format" must be png or jpeg`);
+  }
+
+  const waitUntil = (params.get("wait_until") ?? params.get("waitUntil") ?? config.defaultWaitUntil) as string;
+  if (!WAIT_UNTIL.has(waitUntil)) {
+    throw new HttpError(400, `Parameter "wait_until" must be one of ${[...WAIT_UNTIL].join(", ")}`);
+  }
+
+  const floatParam = (names: string[], fallback: number): number => {
+    for (const name of names) {
+      const raw = params.get(name);
+      if (raw === null) continue;
+      const n = Number(raw);
+      if (!Number.isFinite(n)) throw new HttpError(400, `Parameter "${name}" must be a number`);
+      return n;
+    }
+    return fallback;
+  };
+
+  const quality = clamp(intParam("quality", 80), 0, 100);
+  const scale = clamp(floatParam(["scale", "device_scale_factor"], 1), 0.1, config.maxDeviceScaleFactor);
+
+  return {
+    url,
+    fullPage: boolParam("full_page") || boolParam("fullPage"),
+    width: clamp(intParam("width", config.defaultWidth), 1, config.maxWidth),
+    height: clamp(intParam("height", config.defaultHeight), 1, config.maxHeight),
+    deviceScaleFactor: scale,
+    format: format === "jpg" ? "jpeg" : (format as "png" | "jpeg"),
+    quality,
+    waitUntil: waitUntil as ShotOptions["waitUntil"],
+    timeout: clamp(intParam("timeout", config.defaultTimeoutMs), 1_000, config.maxTimeoutMs),
+    delay: clamp(intParam("delay", 0), 0, config.maxDelayMs),
+    colorScheme: boolParam("dark") ? "dark" : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+function helpDocument(): unknown {
+  const base = `http://localhost:${config.port}`;
+  return {
+    name: "shot",
+    version: VERSION,
+    description:
+      "No-auth screenshot service. Renders a URL to an image using Playwright over CDP.",
+    backend: backendDescription(),
+    routes: {
+      "GET /": "This help document.",
+      "GET /health": "Liveness probe + browser backend status.",
+      "GET /screenshot?url=<URL>": "Render a page to PNG (default) or JPEG.",
+      "GET /openapi.json": "OpenAPI 3.1 specification.",
+    },
+    screenshot_params: {
+      url: "required — absolute http(s) URL to capture",
+      full_page: "bool (default false) — capture full scrollable page",
+      width: "int (default 1280) — viewport width",
+      height: "int (default 800) — viewport height",
+      format: "png | jpeg (default png)",
+      quality: "int 0-100 (jpeg only, default 80)",
+      scale: "number (default 1) — device scale factor / DPR",
+      wait_until: "load | domcontentloaded | networkidle | commit (default load)",
+      delay: "int ms (default 0) — extra wait after load",
+      timeout: `int ms (default ${config.defaultTimeoutMs}, max ${config.maxTimeoutMs})`,
+      dark: "bool (default false) — emulate prefers-color-scheme: dark",
+    },
+    examples: [
+      `${base}/screenshot?url=https://example.com`,
+      `${base}/screenshot?url=https://news.ycombinator.com&full_page=true`,
+      `${base}/screenshot?url=https://example.com&width=1920&height=1080&format=jpeg&quality=80`,
+      `${base}/screenshot?url=https://example.com&dark=true&scale=2`,
+      `curl '${base}/screenshot?url=https://example.com' -o shot.png`,
+    ],
+    notes: [
+      "No authentication. By default, requests to private/loopback/metadata addresses are refused (set ALLOW_PRIVATE_IPS=true to allow).",
+      "Rendered by Chromium — bundled by default, or an external CDP backend via CDP_URL.",
+    ],
+  };
+}
+
+async function handleHealth(res: http.ServerResponse): Promise<void> {
+  let browserConnected = false;
+  try {
+    const browser = await getBrowser();
+    browserConnected = browser.isConnected();
+  } catch {
+    browserConnected = false;
+  }
+  const body = {
+    status: browserConnected ? "ok" : "degraded",
+    backend: backendDescription(),
+    browserConnected,
+    uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+    version: VERSION,
+  };
+  sendJson(res, browserConnected ? 200 : 503, body);
+}
+
+async function handleScreenshot(res: http.ServerResponse, params: URLSearchParams): Promise<void> {
+  const rawUrl = params.get("url");
+  if (!rawUrl) {
+    throw new HttpError(400, 'Missing required query parameter "url"');
+  }
+  const validated = await assertUrlAllowed(rawUrl);
+  const opts = parseShotOptions(params, validated.toString());
+
+  let image: Buffer;
+  try {
+    image = await takeScreenshot(opts);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new HttpError(502, `Failed to render ${opts.url}: ${message}`);
+  }
+
+  res.writeHead(200, {
+    "content-type": opts.format === "jpeg" ? "image/jpeg" : "image/png",
+    "content-length": image.length,
+    "cache-control": "no-store",
+    "content-disposition": `inline; filename="screenshot.${opts.format === "jpeg" ? "jpg" : "png"}"`,
+  });
+  res.end(image);
+}
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+const server = http.createServer((req, res) => {
+  void route(req, res).catch((err) => {
+    if (res.headersSent) {
+      res.destroy();
+      return;
+    }
+    if (err instanceof HttpError) {
+      sendError(res, err.status, err.message);
+    } else {
+      const message = err instanceof Error ? err.message : String(err);
+      sendError(res, 500, `Internal error: ${message}`);
+    }
+  });
+});
+
+async function route(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const method = req.method ?? "GET";
+  const parsed = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const path = parsed.pathname;
+
+  if (method !== "GET" && method !== "HEAD") {
+    throw new HttpError(405, `Method ${method} not allowed`);
+  }
+
+  switch (path) {
+    case "/":
+      return sendJson(res, 200, helpDocument());
+    case "/health":
+    case "/healthz":
+      return handleHealth(res);
+    case "/openapi.json":
+      return sendJson(res, 200, openapiSpec());
+    case "/screenshot":
+      return handleScreenshot(res, parsed.searchParams);
+    case "/favicon.ico":
+      res.writeHead(204);
+      res.end();
+      return;
+    default:
+      throw new HttpError(404, `Not found: ${path}. See GET / for available routes.`);
+  }
+}
+
+server.listen(config.port, config.host, () => {
+  // eslint-disable-next-line no-console
+  console.log(
+    `shot v${VERSION} listening on http://${config.host}:${config.port} (backend: ${backendDescription()}, ssrf-guard: ${config.allowPrivateIps ? "off" : "on"})`,
+  );
+});
+
+// Graceful shutdown.
+let shuttingDown = false;
+async function shutdown(signal: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  // eslint-disable-next-line no-console
+  console.log(`Received ${signal}, shutting down…`);
+  server.close();
+  await closeBrowser();
+  process.exit(0);
+}
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
+process.on("SIGINT", () => void shutdown("SIGINT"));

--- a/shot/src/server.ts
+++ b/shot/src/server.ts
@@ -31,6 +31,7 @@ function sendJson(res: http.ServerResponse, status: number, body: unknown): void
 }
 
 function sendError(res: http.ServerResponse, status: number, message: string): void {
+  if (status === 503 && !res.headersSent) res.setHeader("retry-after", "1");
   sendJson(res, status, { error: { status, message } });
 }
 
@@ -164,6 +165,7 @@ async function handleScreenshot(res: http.ServerResponse, params: URLSearchParam
   try {
     image = await takeScreenshot(opts);
   } catch (err) {
+    if (err instanceof HttpError) throw err; // e.g. 503 queue-full — preserve status
     const message = err instanceof Error ? err.message : String(err);
     throw new HttpError(502, `Failed to render ${opts.url}: ${message}`);
   }

--- a/shot/src/ssrf.ts
+++ b/shot/src/ssrf.ts
@@ -1,0 +1,91 @@
+// Best-effort SSRF guard. Because the service has no auth, by default it refuses
+// to fetch URLs that resolve to private / loopback / link-local / cloud-metadata
+// addresses (e.g. http://169.254.169.254/). This is a guard rail, not a complete
+// defence: it does not protect against DNS rebinding or redirects to private
+// hosts mid-navigation. Disable with ALLOW_PRIVATE_IPS=true on trusted networks.
+
+import dns from "node:dns/promises";
+import net from "node:net";
+import { config } from "./config";
+import { HttpError } from "./errors";
+
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return false;
+  const [a, b] = parts;
+  if (a === 0) return true; // "this" network
+  if (a === 10) return true; // private
+  if (a === 127) return true; // loopback
+  if (a === 169 && b === 254) return true; // link-local + AWS/GCP metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // private
+  if (a === 192 && b === 168) return true; // private
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT (100.64/10)
+  return false;
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const x = ip.toLowerCase().replace(/^\[|\]$/g, "");
+  if (x === "::1" || x === "::") return true; // loopback / unspecified
+  if (x.startsWith("fe80")) return true; // link-local
+  if (x.startsWith("fc") || x.startsWith("fd")) return true; // unique-local
+  if (x.startsWith("::ffff:")) return isPrivateIPv4(x.slice(7)); // IPv4-mapped
+  return false;
+}
+
+function isPrivateAddress(ip: string): boolean {
+  const family = net.isIP(ip);
+  if (family === 4) return isPrivateIPv4(ip);
+  if (family === 6) return isPrivateIPv6(ip);
+  return false;
+}
+
+/**
+ * Validate a user-supplied URL: must be http(s) and (unless allowed) must not
+ * resolve to a private address. Returns the parsed URL on success.
+ */
+export async function assertUrlAllowed(raw: string): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new HttpError(400, `Invalid url: ${JSON.stringify(raw)}`);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new HttpError(400, `Unsupported protocol "${url.protocol}" (only http and https)`);
+  }
+
+  if (config.allowPrivateIps) return url;
+
+  const host = url.hostname.toLowerCase();
+
+  if (host === "localhost" || host.endsWith(".localhost")) {
+    throw new HttpError(403, "Refusing to fetch localhost (set ALLOW_PRIVATE_IPS=true to allow)");
+  }
+
+  // IP literal in the URL — check directly, no DNS needed.
+  if (net.isIP(host)) {
+    if (isPrivateAddress(host)) {
+      throw new HttpError(403, `Refusing private/loopback address ${host} (set ALLOW_PRIVATE_IPS=true to allow)`);
+    }
+    return url;
+  }
+
+  // Resolve the hostname and reject if any record is private.
+  let records: { address: string }[];
+  try {
+    records = await dns.lookup(host, { all: true });
+  } catch {
+    throw new HttpError(400, `Cannot resolve host: ${host}`);
+  }
+  for (const { address } of records) {
+    if (isPrivateAddress(address)) {
+      throw new HttpError(
+        403,
+        `Refusing ${host}: resolves to private address ${address} (set ALLOW_PRIVATE_IPS=true to allow)`,
+      );
+    }
+  }
+
+  return url;
+}

--- a/shot/tsconfig.json
+++ b/shot/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds **`shot/`** — a tiny no-auth screenshot service. Give it a URL, get a PNG/JPEG. Renders with Playwright driving Chromium over CDP. TypeScript on Node, plain `node:http`, single runtime dep (`playwright`).

## Routes
- `GET /` — help JSON (routes + examples)
- `GET /health` — liveness + browser backend status
- `GET /screenshot?url=<URL>` — render to image (`full_page`, `width`/`height`, `format`, `quality`, `scale`, `wait_until`, `delay`, `timeout`, `dark`)
- `GET /openapi.json` — OpenAPI 3.1 spec

## Architecture
Container entrypoint (`scripts/supervisor.mjs`) supervises **two processes** — a Chromium CDP server + the screenshot server that `connectOverCDP`s to it — restarting either on failure. Set `CDP_URL` to reuse an external CDP backend (Chrome pool / browserless) instead of launching Chromium.

## Also included
- SSRF guard (refuses private/loopback/metadata targets, on by default; `ALLOW_PRIVATE_IPS=true` to disable)
- Resource ceilings + concurrency semaphore, graceful SIGTERM shutdown, Docker `HEALTHCHECK`
- [`DEPLOY.md`](./shot/DEPLOY.md): provider recipes (Fly.io, Cloud Run, Railway/Render, Dokploy/Hetzner, docker compose) + sizing + "put it behind auth" checklist

## Verified end-to-end (built container, `shot:test`)
- Container boots **healthy** (HEALTHCHECK passing)
- All 4 routes; real PNG (1024×768, visually confirmed) + JPEG/full_page
- Error/SSRF paths: no-url→400, cloud-metadata→403, `file://`→400, unknown→404
- In-container Chromium kill → supervisor restart → app reconnects → screenshot works
- Graceful `docker stop` (~0.3s, both processes handle SIGTERM)
- `tsc --noEmit` clean

## Note on lightpanda
lightpanda was the original target but is **renderless** — no graphics engine, so it can't produce pixels (`Page.captureScreenshot` returns a placeholder, not a render; lightpanda issues #492/#1988/#2228). Chromium does the rendering; `CDP_URL` keeps the backend pluggable.